### PR TITLE
Change Mesh CR scope to namespace

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -9,6 +9,7 @@ repo: github.com/greymatter-io/operator
 resources:
 - api:
     crdVersion: v1
+    namespaced: true
   domain: greymatter.io
   kind: Mesh
   path: github.com/greymatter-io/operator/api/v1alpha1

--- a/api/v1alpha1/mesh_types.go
+++ b/api/v1alpha1/mesh_types.go
@@ -32,7 +32,7 @@ type MeshStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
+//+kubebuilder:resource:scope=Namespace
 
 // Mesh is the Schema for the meshes API
 type Mesh struct {

--- a/config/crd/bases/greymatter.io_meshes.yaml
+++ b/config/crd/bases/greymatter.io_meshes.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: MeshList
     plural: meshes
     singular: mesh
-  scope: Cluster
+  scope: Namespace
   versions:
   - name: v1alpha1
     schema:


### PR DESCRIPTION
Mesh custom resources should be created in a namespace, the same namespace where the core services will be installed.