### PR TITLE
Update CLI command registry flags

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,8 +60,8 @@ var kubernetesCommand = cli.Command{
 	Action: func(c *cli.Context) error {
 		return loadManifests("context/kubernetes-options", manifestConfig{
 			DockerImageURL:               c.String("image"),
-			DockerUsername:               c.String("username"),
-			DockerPassword:               c.String("password"),
+			DockerUsername:               c.String("registry-username"),
+			DockerPassword:               c.String("registry-password"),
 			DisableWebhookCertGeneration: c.Bool("disable-internal-ca"),
 		})
 	},


### PR DESCRIPTION
The names were changed to registry-username and registry-password, but this
required change (where we actually pull in values) was left behind