### PR TITLE
WIP Remove Prometheus

### DIFF
--- a/pkg/fabric/cue/api.cue
+++ b/pkg/fabric/cue/api.cue
@@ -8,7 +8,7 @@
 	api_spec_endpoint?: string
 	description?: string
 	enable_instance_metrics: true
-	enable_historical_metrics: *false | bool
+	enable_historical_metrics: false
 }
 
 // Cluster
@@ -342,7 +342,7 @@
 		metrics_host: string
 		metrics_port: int
     metrics_dashboard_uri_path: string
-    metrics_prometheus_uri_path: string
+    metrics_prometheus_uri_path: *"" | string
     metrics_ring_buffer_size: int
     prometheus_system_metrics_interval_seconds: int
     metrics_key_function: string

--- a/pkg/fabric/cue/fabric.cue
+++ b/pkg/fabric/cue/fabric.cue
@@ -112,7 +112,6 @@ service: {
           metrics_host: "0.0.0.0"
           metrics_port: 8081
           metrics_dashboard_uri_path: "/metrics"
-          metrics_prometheus_uri_path: "prometheus"
           metrics_ring_buffer_size: 4096
           prometheus_system_metrics_interval_seconds: 15
           metrics_key_function: "depth"

--- a/pkg/version/cue.mod/components.cue
+++ b/pkg/version/cue.mod/components.cue
@@ -122,7 +122,7 @@ catalog: #Component & {
       extensions:
         metrics:
           sessions:
-            redis_example:
+            redis:
               client_type: redis
               connection_string: redis://127.0.0.1:10910
     """
@@ -135,8 +135,7 @@ dashboard: #Component & {
   env: {
     BASE_URL: "/services/dashboard/"
     FABRIC_SERVER: "/services/catalog/"
-    CONFIG_SERVER: =~"^/services/control/api/"
-    PROMETHEUS_SERVER: "/services/prometheus/api/v1/"
+    CONFIG_SERVER: "/services/control/api/v1.0"
     REQUEST_TIMEOUT: "15000"
     USE_PROMETHEUS: "false"
     DISABLE_PROMETHEUS_ROUTES_UI: "true"
@@ -227,24 +226,4 @@ redis: #Component & {
     resources: requests: storage: "40Gi"
     volumeMode: "Filesystem"
   }
-}
-
-// TODO: Not currently being installed
-prometheus: #Component & {
-  name: "gm-prometheus"
-  isStatefulset: true
-  image: =~"^prom/prometheus:"
-  command: "/bin/prometheus"
-  args: [
-    "--query.timeout=4m",
-    "--query.max-samples=5000000000",
-    "--storage.tsdb.path=/var/lib/prometheus/data/data",
-    "--config.file=/etc/prometheus/prometheus.yaml",
-    "--web.console.libraries=/usr/share/prometheus/console_libraries",
-    "--web.console.templates=/usr/share/prometheus/consoles",
-    "--web.enable-admin-api",
-    "--web.external-url=http://anything/services/prometheus/latest", // TODO
-    "--web.route-prefix=/"
-  ]
-  ports: prom: 9090
 }

--- a/pkg/version/cue.mod/inputs.cue
+++ b/pkg/version/cue.mod/inputs.cue
@@ -22,6 +22,6 @@ controlNamespaces: strings.Join([
 
 JWT: {
   userTokens: *"[]" | string
-  apiKey: "" | string
-  privateKey: "" | string
+  apiKey: *"" | string
+  privateKey: *"" | string
 }

--- a/pkg/version/cue.mod/outputs.cue
+++ b/pkg/version/cue.mod/outputs.cue
@@ -14,7 +14,6 @@ manifests: [...#ManifestGroup] & [
   { _c: [control, control_api] },
   { _c: [catalog] },
   { _c: [dashboard] },
-  // { _c: [prometheus] }, // TODO
 ]
 
 #ManifestGroup: {

--- a/pkg/version/versions/1.6.cue
+++ b/pkg/version/versions/1.6.cue
@@ -16,12 +16,6 @@ catalog: {
 
 dashboard: {
   image: "docker.greymatter.io/release/gm-dashboard:5.1.1"
-  env: {
-    BASE_URL: "/services/dashboard/"
-    FABRIC_SERVER: "/services/catalog/"
-    CONFIG_SERVER: "/services/control/api/v1.0"
-    PROMETHEUS_SERVER: "/services/prometheus/api/v1/"
-  }
 }
 
 jwt_security: {

--- a/pkg/version/versions/1.7.cue
+++ b/pkg/version/versions/1.7.cue
@@ -16,9 +16,6 @@ catalog: {
 
 dashboard: {
   image: "docker.greymatter.io/development/gm-dashboard:6.0.0-rc.2"
-  env: {
-    CONFIG_SERVER: "/services/control/api/v1.0"
-  }
 }
 
 jwt_security: {


### PR DESCRIPTION
Removes Prometheus from a Mesh's core installation. Prometheus is an optional dependency and shouldn't be installed directly by our operator.

TODO: How to support Prometheus if installed via another process.