### PR TITLE
WIP (need redesign): Enable standalone proxy container in pod

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
 	"sync"
 
 	"cuelang.org/go/cue"
@@ -133,9 +134,11 @@ func (c *CLI) ConfigureService(mesh, workload string, annotations map[string]str
 
 	ingresses := make(map[string]int32)
 	for _, container := range containers {
-		for _, port := range container.Ports {
-			if port.Name != "" || len(container.Ports) == 1 {
-				ingresses[port.Name] = port.ContainerPort
+		if !strings.Contains(container.Image, "gm-proxy") {
+			for _, port := range container.Ports {
+				if port.Name != "" || len(container.Ports) == 1 {
+					ingresses[port.Name] = port.ContainerPort
+				}
 			}
 		}
 	}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -129,9 +129,11 @@ func (c *CLI) ConfigureService(mesh, workload string, annotations map[string]str
 		return
 	}
 
-	// TODO: Handle removals of containers and annotations.
+	// TODO: Handle removals of containers and annotations by deleting the resulting mesh configs (e.g. ingress, egress).
 	// We'll need to be able to pass previous annotations and containers, or even a diff with actions for what to add/edit/remove.
 
+	// Identify named container ports in the Pod template for specifying ingress from 10808 -> {port}.
+	// The only exception here is if the container image contains "gm-proxy", which signals to us that this should be a standalone data plane.
 	ingresses := make(map[string]int32)
 	for _, container := range containers {
 		if !strings.Contains(container.Image, "gm-proxy") {

--- a/pkg/fabric/cue/test_inputs.cue
+++ b/pkg/fabric/cue/test_inputs.cue
@@ -1,0 +1,34 @@
+package fabric
+
+// This file is for manually testing various inputs with the cue CLI.
+// i.e. "cue eval -e service.routes"
+
+MeshName: "m"
+ReleaseVersion: "1.7"
+Zone: "z"
+ServiceName: "mock"
+Ingresses: {}
+IngressTCPPortName: ""
+HTTPEgresses: [
+  {
+    isExternal: false
+    cluster: "mock2"
+    host: ""
+    port: 0
+    tcpPort: 0
+  },
+  {
+    isExternal: true
+    cluster: "lambda"
+    host: "something.com"
+    port: 80
+    tcpPort: 0
+  },
+]
+TCPEgresses: [{
+  isExternal: false
+  cluster: "gm-redis"
+  host: ""
+  port: 0
+  tcpPort: 10910
+}]

--- a/pkg/webhooks/workloads.go
+++ b/pkg/webhooks/workloads.go
@@ -49,6 +49,11 @@ func (wd *workloadDefaulter) handlePod(req admission.Request) admission.Response
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
+	// Ensure the pod exists in a namespace watched by the operator.
+	if wd.WatchedBy(req.Namespace) == "" {
+		return admission.ValidationResponse(true, "allowed")
+	}
+
 	// Check for a cluster label; if not found, this pod does not belong to a Mesh.
 	xdsCluster, ok := pod.Labels["greymatter.io/cluster"]
 	if !ok {

--- a/pkg/webhooks/workloads.go
+++ b/pkg/webhooks/workloads.go
@@ -82,7 +82,15 @@ func (wd *workloadDefaulter) handlePod(req admission.Request) admission.Response
 	}
 
 	// Inject volumes to mount in the sidecar
-	pod.Spec.Volumes = append(pod.Spec.Volumes, sidecar.Volumes...)
+	volumes := make(map[string]struct{})
+	for _, vol := range pod.Spec.Volumes {
+		volumes[vol.Name] = struct{}{}
+	}
+	for _, vol := range sidecar.Volumes {
+		if _, ok := volumes[vol.Name]; !ok {
+			pod.Spec.Volumes = append(pod.Spec.Volumes, vol)
+		}
+	}
 
 	// Inject a reference to the image pull secret
 	var hasImagePullSecret bool


### PR DESCRIPTION
This injects a standalone gm-proxy into a pod and generates basic mesh configs (no ingress obviously)
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: name
  namespace: namespace
spec:
  selector:
    matchLabels:
      app: name
  template:
    metadata:
      labels:
        app: name
    spec:
      containers:
      - name: anything
        image: gm-proxy # required
        ports:
          - name: proxy # required
            containerPort: 10808 # required
            protocol: TCP 
        resources: {}
```