### PR TITLE
Remove kustomize from bootstrap script

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -2,7 +2,7 @@
 
 set -e
 
-for dependency in go greymatter operator-sdk kustomize cue staticcheck git
+for dependency in go greymatter operator-sdk cue staticcheck git
 do
     if ! which $dependency &> /dev/null; then
         echo "$dependency is missing from your \$PATH"


### PR DESCRIPTION
`kustomize` CLI is no longer needed for working in this project since we import its Go API directly. It's also available via `kubectl apply -k`.