### PR TITLE
Do not set require_tls on clusters by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ short-form.
 
 ## Prerequisites
 
-It is assumed that you have kubectl installed with cluster administrator access.
+It is assumed that you have [kubectl v1.21+](https://kubernetes.io/docs/tasks/tools/) installed with cluster administrator access.
 
 Next, ensure you have the following environment variables sourced: `GREYMATTER_REGISTRY_USERNAME` and
 `GREYMATTER_REGISTRY_PASSWORD`. These require your credentials for pulling Grey Matter core service
@@ -21,7 +21,6 @@ To get the latest development version of the operator up and running in your Kub
 the following:
 
 ```
-
 kubectl apply -k config/context/kubernetes
 
 kubectl create secret docker-registry gm-docker-secret \

--- a/pkg/cuemodule/meshconfigs/defaults.cue
+++ b/pkg/cuemodule/meshconfigs/defaults.cue
@@ -43,7 +43,6 @@ _ServiceVersions: {
 	cluster_key: string
 	name:        *cluster_key | string
 	zone_key:    mesh.spec.zone
-	require_tls: true
 }
 
 #Route: greymatter.#Route & {


### PR DESCRIPTION
Reverts an addition to mesh config default values. `require_tls` should not be set on _all_ clusters by default. Instead, `require_tls` is set on clusters that are upstreams of:
- [edge](https://github.com/greymatter-io/operator/blob/8ef1e52fe3484ce3442e684e300e8c3507ed98c0/pkg/cuemodule/meshconfigs/spire.cue#L18)
- [other workloads](https://github.com/greymatter-io/operator/blob/8ef1e52fe3484ce3442e684e300e8c3507ed98c0/pkg/cuemodule/meshconfigs/spire.cue#L46)
