### PR TITLE
Bump spire version to fix Spire attestation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+## Fixed
+
+- Updated versions of Spire images (spire-server, spire-agent, and the k8s-workload-registrar) that
+  the operator installs to 1.2.0. This fixes an issue on some platforms where Spire would
+  misidentify the process as non-k8s, and fail to issue an identity.
+
 ## 0.3.1 (January 31, 2022)
 
 This release includes internal changes to how we source Grey Matter mesh configuration schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## Unreleased
 
-## Fixed
+## Changed
 
 - Updated versions of Spire images (spire-server, spire-agent, and the k8s-workload-registrar) that
   the operator installs to 1.2.0. This fixes an issue on some platforms where Spire would
   misidentify the process as non-k8s, and fail to issue an identity.
+
+- Specifying `--platform linux/amd64` in docker and buildah container builds to ensure M1
+  Macs know what to do with it, regardless of where it was built.
 
 ## 0.3.1 (January 31, 2022)
 

--- a/pkg/installer/spire.yaml
+++ b/pkg/installer/spire.yaml
@@ -56,7 +56,7 @@ statefulset:
       spec:
         containers:
         - name: server
-          image: gcr.io/spiffe-io/spire-server:1.0.2
+          image: gcr.io/spiffe-io/spire-server:1.2.0
           imagePullPolicy: IfNotPresent
           args:
           - -config
@@ -88,7 +88,7 @@ statefulset:
             mountPath: /run/spire/data
           resources: {}
         - name: registrar
-          image: gcr.io/spiffe-io/k8s-workload-registrar:0.12.0
+          image: gcr.io/spiffe-io/k8s-workload-registrar:1.2.0
           imagePullPolicy: IfNotPresent
           args:
           - -config
@@ -161,7 +161,7 @@ daemonset:
           resources: {}
         containers:
         - name: agent
-          image: gcr.io/spiffe-io/spire-agent:1.0.2
+          image: gcr.io/spiffe-io/spire-agent:1.2.0
           imagePullPolicy: IfNotPresent
           args:
           - -config

--- a/scripts/build
+++ b/scripts/build
@@ -21,6 +21,7 @@ cmd_help () {
 _buildah_build () {
   local tag=$1
   buildah bud \
+    --platform linux/amd64 \
     --build-arg username=$GREYMATTER_REGISTRY_USERNAME \
     --build-arg password=$GREYMATTER_REGISTRY_PASSWORD \
     -t "$tag" --layers -f Dockerfile .
@@ -29,6 +30,7 @@ _buildah_build () {
 _docker_build () {
   local tag=$1
   docker build \
+  --platform linux/amd64 \
   --build-arg username=$GREYMATTER_REGISTRY_USERNAME \
   --build-arg password=$GREYMATTER_REGISTRY_PASSWORD \
   -t "$tag" -f Dockerfile .


### PR DESCRIPTION
Updated the versions of Spire images (spire-server, spire-agent, and the k8s-workload-registrar) that the operator installs to 1.2.0. This fixes an issue on some platforms where Spire would misidentify the process as non-k8s, and fail to issue an identity, causing a chain of failures when the static config of the control-api, catalog, and gm-redis sidecars fail to make connections.