### PR TITLE
Increasing limits and timeouts for Rancher Desktop

### DIFF
--- a/config/base/deployment/deployment.yaml
+++ b/config/base/deployment/deployment.yaml
@@ -31,20 +31,20 @@ spec:
           httpGet:
             path: /healthz
             port: 8081
-          initialDelaySeconds: 15
+          initialDelaySeconds: 120
           periodSeconds: 20
         readinessProbe:
           httpGet:
             path: /readyz
             port: 8081
-          initialDelaySeconds: 5
+          initialDelaySeconds: 120
           periodSeconds: 10
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 300Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 150Mi
       serviceAccountName: operator
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
For whatever reason, the operator uses >=177MiB for a simple Grey Matter deployment, and then rests at ~154MiB, so I increased the memory limit to 300. The liveness and readiness probes were also causing trouble, so I increased both of their initialDelaySeconds to 120 to accommodate slower/emulated machines (such as my M1 Mac).

With these changes, the mesh comes up in ~2 minutes from scratch, using either the dockerd or containerd runtime for Rancher Desktop.