### PR TITLE
swapping out deprecated flag in spire server health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Updated flag in spire server liveness probe to prevent an eventual crash of spire server.
+
 ## 0.3.2 (February 10, 2022)
 
 This release includes internal changes to how we source Grey Matter mesh configuration schema.

--- a/pkg/installer/spire.yaml
+++ b/pkg/installer/spire.yaml
@@ -70,7 +70,7 @@ statefulset:
               command:
               - /opt/spire/bin/spire-server
               - healthcheck
-              - --registrationUDSPath=/run/spire/socket/registration.sock
+              - -socketPath=/run/spire/socket/registration.sock
             failureThreshold: 2
             initialDelaySeconds: 15
             periodSeconds: 60


### PR DESCRIPTION
`--registrationUDSPath` is a deprecated way of specifying the UDS path, and we recently updated the Spire components. The new flag is `-socketPath`. This fixes a bug where the liveness probe on spire server would eventually fail, causing Kubernetes to kill the container.