### PR TITLE
Remove unix WorkloadAttestor from spire config

### DIFF
--- a/pkg/installer/spire.yaml
+++ b/pkg/installer/spire.yaml
@@ -439,8 +439,4 @@ configmaps:
             skip_kubelet_verification = true
           }
         }
-        WorkloadAttestor "unix" {
-          plugin_data {
-          }
-        }
       }


### PR DESCRIPTION
Since our spire config is all-k8s, we shouldn't need this workload
attestor. This might save us some spam in the logs.
