### PR TITLE
Add e2e VM build

### DIFF
--- a/.buildkite/e2e_vm.yaml
+++ b/.buildkite/e2e_vm.yaml
@@ -1,0 +1,5 @@
+steps:
+  - label: "kickoff build"
+    commands: 
+      - echo "hello world"
+


### PR DESCRIPTION
Adding (temporarily?) a separate buildkite file, constrained to a
baremetal host. Right now this is one of my lesser-used computers.

We need a baremetal host, because we want to create a build that
launches a full-blown Ubuntu virtual machine. This is possible with the
standard LXD images by just passing `--vm` plus some optional config
parameters.

We need a VM instead of a linux container, because we want to launch an
ephemeral, single-node Kubernetes environment inside.

Again, the actual buildkite agent runs on bare metal, and must be given
access to lxd. Once that's done, standup/teardown can be orchestrated
from outside the VM, with the lxc cli.
