### PR TITLE
Add annotation for disabling sidecar configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Add a debug build mode that starts a pprof server automatically.
+- Added an annotation to control whether sidecar configuration is created for a given Deployment
+  or StatefulSet, e.g., `greymatter.io/configure-sidecar: "false"`
 
 ### Fixed
 

--- a/pkg/cuemodule/base/wellknown.cue
+++ b/pkg/cuemodule/base/wellknown.cue
@@ -1,0 +1,7 @@
+package base
+
+#ANNOTATION_CONFIGURE_SIDECAR: "greymatter.io/configure-sidecar"
+#ANNOTATION_LAST_APPLIED:      "greymatter.io/last-applied"
+#LABEL_CLUSTER:                "greymatter.io/cluster"
+#LABEL_WORKLOAD:               "greymatter.io/workload"
+#LABEL_COMPONENT:              "greymatter.io/component"

--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -2,6 +2,7 @@ package installer
 
 import (
 	"context"
+	"github.com/greymatter-io/operator/pkg/wellknown"
 	"time"
 
 	"github.com/greymatter-io/operator/api/v1alpha1"
@@ -81,7 +82,7 @@ func (i *Installer) ApplyMesh(prev, mesh *v1alpha1.Mesh) {
 			if deployment.Annotations == nil {
 				deployment.Annotations = make(map[string]string)
 			}
-			deployment.Annotations["greymatter.io/last-applied"] = time.Now().String()
+			deployment.Annotations[wellknown.ANNOTATION_LAST_APPLIED] = time.Now().String()
 			k8sapi.Apply(i.client, &deployment, nil, k8sapi.CreateOrUpdate)
 		}
 	}
@@ -92,7 +93,7 @@ func (i *Installer) ApplyMesh(prev, mesh *v1alpha1.Mesh) {
 			if statefulset.Annotations == nil {
 				statefulset.Annotations = make(map[string]string)
 			}
-			statefulset.Annotations["greymatter.io/last-applied"] = time.Now().String()
+			statefulset.Annotations[wellknown.ANNOTATION_LAST_APPLIED] = time.Now().String()
 			k8sapi.Apply(i.client, &statefulset, nil, k8sapi.CreateOrUpdate)
 		}
 	}
@@ -186,9 +187,9 @@ func (i *Installer) RemoveMesh(mesh *v1alpha1.Mesh) {
 				if deployment.Spec.Template.Labels == nil {
 					deployment.Spec.Template.Labels = make(map[string]string)
 				}
-				if _, ok := deployment.Spec.Template.Labels["greymatter.io/cluster"]; ok {
-					delete(deployment.Spec.Template.Labels, "greymatter.io/cluster")
-					delete(deployment.Spec.Template.Labels, "greymatter.io/workload")
+				if _, ok := deployment.Spec.Template.Labels[wellknown.LABEL_CLUSTER]; ok {
+					delete(deployment.Spec.Template.Labels, wellknown.LABEL_CLUSTER)
+					delete(deployment.Spec.Template.Labels, wellknown.LABEL_WORKLOAD)
 					k8sapi.Apply(i.client, &deployment, nil, k8sapi.CreateOrUpdate)
 				}
 			}
@@ -203,9 +204,9 @@ func (i *Installer) RemoveMesh(mesh *v1alpha1.Mesh) {
 				if statefulset.Spec.Template.Labels == nil {
 					statefulset.Spec.Template.Labels = make(map[string]string)
 				}
-				if _, ok := statefulset.Spec.Template.Labels["greymatter.io/cluster"]; ok {
-					delete(statefulset.Spec.Template.Labels, "greymatter.io/cluster")
-					delete(statefulset.Spec.Template.Labels, "greymatter.io/workload")
+				if _, ok := statefulset.Spec.Template.Labels[wellknown.LABEL_CLUSTER]; ok {
+					delete(statefulset.Spec.Template.Labels, wellknown.LABEL_CLUSTER)
+					delete(statefulset.Spec.Template.Labels, wellknown.LABEL_WORKLOAD)
 					k8sapi.Apply(i.client, &statefulset, nil, k8sapi.CreateOrUpdate)
 				}
 			}

--- a/pkg/webhooks/workloads.go
+++ b/pkg/webhooks/workloads.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/greymatter-io/operator/pkg/cli"
 	"github.com/greymatter-io/operator/pkg/installer"
+	"github.com/greymatter-io/operator/pkg/wellknown"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -51,7 +52,7 @@ func (wd *workloadDefaulter) handlePod(req admission.Request) admission.Response
 	}
 
 	// Check for a cluster label; if not found, this pod does not belong to a Mesh.
-	xdsCluster, ok := pod.Labels["greymatter.io/cluster"]
+	xdsCluster, ok := pod.Labels[wellknown.LABEL_CLUSTER]
 	if !ok {
 		return admission.ValidationResponse(true, "allowed")
 	}
@@ -112,7 +113,7 @@ func (wd *workloadDefaulter) handleWorkload(req admission.Request) admission.Res
 			if deployment.Annotations == nil {
 				deployment.Annotations = make(map[string]string)
 			}
-			deployment.Annotations["greymatter.io/last-applied"] = time.Now().String()
+			deployment.Annotations[wellknown.ANNOTATION_LAST_APPLIED] = time.Now().String()
 			deployment.Spec.Template = addClusterLabels(deployment.Spec.Template, mesh, req.Name)
 			rawUpdate, err = json.Marshal(deployment)
 			if err != nil {
@@ -120,7 +121,9 @@ func (wd *workloadDefaulter) handleWorkload(req admission.Request) admission.Res
 				return admission.ValidationResponse(false, "failed to add cluster label")
 			}
 			logger.Info("added cluster label", "kind", req.Kind.Kind, "name", req.Name, "namespace", req.Namespace)
-			go wd.ConfigureService(mesh, req.Name, deployment)
+			if deployment.Annotations[wellknown.ANNOTATION_CONFIGURE_SIDECAR] != "false" {
+				go wd.ConfigureService(mesh, req.Name, deployment)
+			}
 		} else {
 			wd.DecodeRaw(req.OldObject, deployment)
 			go wd.RemoveService(mesh, req.Name, deployment)
@@ -134,7 +137,7 @@ func (wd *workloadDefaulter) handleWorkload(req admission.Request) admission.Res
 			if statefulset.Annotations == nil {
 				statefulset.Annotations = make(map[string]string)
 			}
-			statefulset.Annotations["greymatter.io/last-applied"] = time.Now().String()
+			statefulset.Annotations[wellknown.ANNOTATION_LAST_APPLIED] = time.Now().String()
 			statefulset.Spec.Template = addClusterLabels(statefulset.Spec.Template, mesh, req.Name)
 			rawUpdate, err = json.Marshal(statefulset)
 			if err != nil {
@@ -142,7 +145,10 @@ func (wd *workloadDefaulter) handleWorkload(req admission.Request) admission.Res
 				return admission.ValidationResponse(false, "failed to add cluster label")
 			}
 			logger.Info("added cluster label", "kind", req.Kind.Kind, "name", req.Name, "namespace", req.Namespace)
-			go wd.ConfigureService(mesh, req.Name, statefulset)
+
+			if statefulset.Annotations[wellknown.ANNOTATION_CONFIGURE_SIDECAR] != "false" {
+				go wd.ConfigureService(mesh, req.Name, statefulset)
+			}
 		} else {
 			wd.DecodeRaw(req.OldObject, statefulset)
 			go wd.RemoveService(mesh, req.Name, statefulset)
@@ -157,7 +163,7 @@ func addClusterLabels(tmpl corev1.PodTemplateSpec, mesh, name string) corev1.Pod
 	if tmpl.Labels == nil {
 		tmpl.Labels = make(map[string]string)
 	}
-	tmpl.Labels["greymatter.io/cluster"] = name
-	tmpl.Labels["greymatter.io/workload"] = fmt.Sprintf("%s.%s", mesh, name)
+	tmpl.Labels[wellknown.LABEL_CLUSTER] = name
+	tmpl.Labels[wellknown.LABEL_WORKLOAD] = fmt.Sprintf("%s.%s", mesh, name)
 	return tmpl
 }

--- a/pkg/webhooks/workloads.go
+++ b/pkg/webhooks/workloads.go
@@ -126,7 +126,9 @@ func (wd *workloadDefaulter) handleWorkload(req admission.Request) admission.Res
 			}
 		} else {
 			wd.DecodeRaw(req.OldObject, deployment)
-			go wd.RemoveService(mesh, req.Name, deployment)
+			if deployment.Annotations[wellknown.ANNOTATION_CONFIGURE_SIDECAR] != "false" {
+				go wd.RemoveService(mesh, req.Name, deployment)
+			}
 			return admission.ValidationResponse(true, "allowed")
 		}
 
@@ -151,7 +153,9 @@ func (wd *workloadDefaulter) handleWorkload(req admission.Request) admission.Res
 			}
 		} else {
 			wd.DecodeRaw(req.OldObject, statefulset)
-			go wd.RemoveService(mesh, req.Name, statefulset)
+			if statefulset.Annotations[wellknown.ANNOTATION_CONFIGURE_SIDECAR] != "false" {
+				go wd.RemoveService(mesh, req.Name, statefulset)
+			}
 			return admission.ValidationResponse(true, "allowed")
 		}
 	}

--- a/pkg/wellknown/wellknown.go
+++ b/pkg/wellknown/wellknown.go
@@ -1,0 +1,8 @@
+package wellknown
+
+const (
+	ANNOTATION_CONFIGURE_SIDECAR = "greymatter.io/configure-sidecar"
+	ANNOTATION_LAST_APPLIED      = "greymatter.io/last-applied"
+	LABEL_CLUSTER                = "greymatter.io/cluster"
+	LABEL_WORKLOAD               = "greymatter.io/workload"
+)


### PR DESCRIPTION
This was necessary to make clear instructions for GitOps-based deployments in our docs, and trivial enough to do in passing.

We've added this annotation to the operator for Deployments and StatefulSets:

```
metadata:
  annotation:
    greymatter.io/configure-sidecar: "false"
```

If set to "false", the operator will inject a sidecar but leave it unconfigured so users can manually configure it.


Also in this PR

- Changelog update
- Some refactoring of magic strings into constants