### PR TITLE
replace `kustomize build` with `kubectl kustomize`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,8 @@ kubectl apply -k config/context/kubernetes --dry-run=client -o yaml
 (NOTE: If deploying to OpenShift, you can replace `config/context/kubernetes` with
 `config/context/openshift`.)
 
-Under the hood, kubectl uses [kustomize](https://kustomize.io). As a convenience, `kustomize` may be
-downloaded to this repo's `bin` directory by using the `make kustomize` target. To generate the raw
-manifests that can be piped into a file after downloading kustomize, run
-
 ```
-./bin/kustomize build config/context/kubernetes
+kubectl kustomize config/context/kubernetes
 ```
 
 ## Using nix-shell

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -89,7 +89,7 @@ release_image() {
 # Note that the bundled deployment manifest points to a docker.greymatter.io/release/gm-operator:$1 image.
 _bundle() {
   sed -i "s/SEMVER_VERSION/$1/" config/olm/manifests/kustomization.yaml
-	kustomize build config/olm/manifests | operator-sdk generate bundle -q --package gm-operator --overwrite --version $1
+	kubectl kustomize config/olm/manifests | operator-sdk generate bundle -q --package gm-operator --overwrite --version $1
 	operator-sdk bundle validate ./bundle
   _build_image "docker.greymatter.io/development/gm-operator-bundle:$1" bundle.Dockerfile
   _push_image "docker.greymatter.io/development/gm-operator-bundle:$1"


### PR DESCRIPTION
[sc-10466]

"Hello Dilbert, I'm the vice-president in charge of immediately implementing ideas..."  
--Dilbert Episode 2

Here's a PR. Do not trust this PR - Make sure this is what you actually want. In particular, please confirm that the CI build container has a new enough version of kubectl that it can still build the operator after this PR.

I'm just throwing something up there because when I went through all of the Operator PRs, two of them stood out as handy and completely trivial, so I resolved to just do them right now. I just naively applied what Brian said here:
https://app.shortcut.com/grey-matter/story/10466/operator-replace-kustomize-cli-with-kubectl
