### PR TITLE
Use ubuntu-2110-ci buildkite container

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -6,4 +6,4 @@ steps:
       - ./scripts/cibuild release
     key: trigger-nexus-push
     agents:
-      container_image: ubuntu-2104-ci
+      container_image: ubuntu-2110-ci

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -4,6 +4,9 @@ steps:
       - ./scripts/cibuild test
       - ./scripts/cibuild build
       - ./scripts/cibuild release
-    key: trigger-nexus-push
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 2
     agents:
       container_image: ubuntu-2110-ci


### PR DESCRIPTION
2104 was built from a non-LTS release, so we upgrade it with the next non-LTS release.

Hopefully we can get rid of non-LTS releases entirely with the next LTS (22.04)