### PR TITLE
Submodules cannot pin to a commit, only track HEAD

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "pkg/cuemodule/greymatter-cue"]
+        branch = pre_refactor
 	path = pkg/cuemodule/greymatter-cue
 	url = https://github.com/greymatter-io/greymatter-cue


### PR DESCRIPTION
We needed to create a branch pre_refactor in the greymatter-cue repo, and we use
that as our submodule. HEAD should be this commit

    36dd308eefd7585fafa6139ce2c29755e674fd58

Once our CUE refactor is done, we can tag releases in greymatter-cue
which submodules can also use.
