### PR TITLE
Remove requirement for operator-sdk in bootstrap

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -2,7 +2,7 @@
 
 set -e
 
-for dependency in go greymatter operator-sdk cue staticcheck git
+for dependency in go greymatter cue staticcheck git
 do
     if ! which $dependency &> /dev/null; then
         echo "$dependency is missing from your \$PATH"


### PR DESCRIPTION
This isn't required to do most of the dev work that's happening these
days, so there's no reason to fail the build for it.
