### PR TITLE
ConfigMap that can be used to override config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ COPY --from=builder /workspace/pkg/cuemodule/k8s /app/k8s
 COPY --from=builder /workspace/greymatter /bin/greymatter
 USER 1000:1000
 
-ENTRYPOINT ["/app/operator"]
+CMD ["/app/operator"]

--- a/pkg/cuemodule/inputs.cue
+++ b/pkg/cuemodule/inputs.cue
@@ -10,8 +10,8 @@ import (
 
 config: {
   // Flags
-  spire: bool | *true // enable Spire-based mTLS DEBUG - the default should be false
-  auto_apply_mesh: bool | *true // apply the default mesh specified above after a delay
+  spire: bool | *true @tag(spire,type=bool) // enable Spire-based mTLS DEBUG - the default should be false
+  auto_apply_mesh: bool | *true @tag(auto_apply_mesh,type=bool) // apply the default mesh specified above after a delay
   generate_webhook_certs: bool | *true
 
   // Values

--- a/pkg/cuemodule/k8s/outputs/operator.cue
+++ b/pkg/cuemodule/k8s/outputs/operator.cue
@@ -21,8 +21,6 @@ operator_namespace: [
   }
 ]
 
-operator_overrides: string | *"" @tag(operator_overrides) // Used to populate the operator_overrides configmap below
-
 operator_crd: [
   // TODO we need the #CustomResourceDefinition definition
   {
@@ -290,7 +288,14 @@ operator_k8s: [
       namespace: "gm-operator"
     }
     data: {
-      "overrides.cue": operator_overrides
+      "overrides.cue": """
+      package only
+
+      config: {
+        spire: \(config.spire)
+        auto_apply_mesh: \(config.auto_apply_mesh)
+      }
+      """
     }
   },
 

--- a/pkg/mesh_install/installer.go
+++ b/pkg/mesh_install/installer.go
@@ -88,19 +88,18 @@ func (i *Installer) Start(ctx context.Context) error {
 		return err
 	}
 
-	logger.Info("Attempting to apply spire server-ca secret")
-	spireSecret := &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "server-ca",
-			Namespace: "spire",
-		},
-	}
-
 	if i.Config.Spire {
+		logger.Info("Attempting to apply spire server-ca secret")
+		spireSecret := &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "server-ca",
+				Namespace: "spire",
+			},
+		}
 		spireSecret, err = injectGeneratedCertificates(spireSecret, i.cfssl)
 		if err != nil {
 			logger.Error(err, "Error while attempting to apply spire server-ca secret", "secret object", spireSecret)
@@ -124,7 +123,7 @@ func (i *Installer) Start(ctx context.Context) error {
 			logger.Info("Waiting 30 seconds to apply loaded default Mesh resource to cluster.")
 			time.Sleep(30 * time.Second) // Sleep for an arbitrary initial duration
 			for {
-				err := k8sapi.Apply(i.k8sClient, i.Mesh, nil, k8sapi.CreateOrUpdate)
+				err := k8sapi.Apply(i.k8sClient, i.Mesh, nil, k8sapi.GetOrCreate)
 				if err == nil {
 					break
 				}


### PR DESCRIPTION
As per this conversation: https://greymatter.slack.com/archives/C07TJSLQ0/p1651009645580309?thread_ts=1650988828.618659&cid=C07TJSLQ0

I've made a new ConfigMap that gets mounted into the operator at `/app/overrides.cue`, allowing a user to override values. At the moment, the point is to let the integration tests flip switches _somehow_, and may not end up being the ultimate solution.

~Personally, I'm not very happy with this, but it'll do for now.~ I've found a version of this I'm happy enough with. See below.