### PR TITLE
Optimize and expand integration tests

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,9 +1,16 @@
 steps:
-  - label: ":shipit: build and release"
+  - label: "run unit tests"
     agents:
       container_image: ubuntu-2110-ci
     commands: 
+      - ./scripts/cibuild bootstrap
       - ./scripts/cibuild test
+  - wait
+  - label: ":shipit: build and release"
+    agents:
+      container_image: ubuntu-2110-ci
+    commands:
+      - ./scripts/cibuild bootstrap
       - ./scripts/cibuild build
       - ./scripts/cibuild export_container "${BUILDKITE_PIPELINE_SLUG}_${BUILDKITE_BUILD_NUMBER}.tar" "docker.greymatter.io/development/gm-operator:latest"
       - ./scripts/cibuild release
@@ -12,8 +19,6 @@ steps:
         - exit_status: "*"
           limit: 2
   - wait
-  - label: "launch ec2 and run integration tests"
+  - label: "run integration tests"
     commands:
-      - ./scripts/cibuild launch_k3s
-      - ./scripts/cibuild generate_integration_pipeline | buildkite-agent pipeline upload
-
+      - ./scripts/cibuild generate_integration_tests

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -2,10 +2,8 @@
 
 set -e
 
-cmd_test () {
+cmd_bootstrap () {
   go mod vendor
-  ./scripts/test lint
-
   (
     cd ./pkg/cuemodule/cue.mod
     cue get go github.com/greymatter-io/operator/api/...
@@ -13,9 +11,15 @@ cmd_test () {
   )
 
   git submodule update --init --recursive --remote
+}
+
+# Runs go tests
+cmd_test () {
+  ./scripts/test lint
   ./scripts/test
 }
 
+# Polls the ec2 for k3s ready state
 cmd_wait_for_k3s () {
   set +e #allow errors temporarily
   echo "Waiting for k3s to become available"
@@ -32,6 +36,7 @@ cmd_wait_for_k3s () {
   set -e
 }
 
+# Creates image secrets inside k3s cluster
 cmd_create_image_pull_secret () {
   set -u
   local name=$1
@@ -44,12 +49,14 @@ cmd_create_image_pull_secret () {
   set +u
 }
 
+# Builds docker image
 cmd_build () {
   # Login to Nexus in order to add the greymatter CLI to the image.
   container-registry-login $NEXUS_USER $NEXUS_PASS
   _build_image "docker.greymatter.io/development/gm-operator:latest" "Dockerfile"
 }
 
+# Build docker image helper
 _build_image () {
   local tag=$1
   local dockerfile=$2
@@ -58,6 +65,7 @@ _build_image () {
   buildah bud $build_args -t "${tag}" --layers -f ${dockerfile} .
 }
 
+# Logs into Nexus, checks if CI is running during a tag release or merge into main and if so pushes assets
 _release_container () {
   container-registry-login $NEXUS_USER $NEXUS_PASS
   local latest="docker.greymatter.io/development/gm-operator:latest"
@@ -71,6 +79,7 @@ _release_container () {
   fi
 }
 
+# Exports docker image into tar
 cmd_export_container () {
   local tarball=$1
   local tag=$2
@@ -78,7 +87,7 @@ cmd_export_container () {
   buildkite-agent artifact upload $tarball
 }
 
-# Build and push an OLM-compatible image of manifests for easy 
+# Build and push an OLM-compatible image of manifests for easy
 # installation in OpenShift cluster contexts.
 _release_bundle() {
   if [[ -n "$BUILDKITE_TAG" ]]; then
@@ -92,40 +101,48 @@ _release_bundle() {
   fi
 }
 
-cmd_generate_integration_pipeline () {
-  # meant to be piped to buildkite-agent
-  echo "
+# Creates the dynamic pipeline that starts up the greymatter mesh environment
+#  in the ephemeral ec2s. The output of the echo commands runs on the ec2, not the original machine running the rest of the pipeline.
 
-steps:
-  - label: \"k3s integration test\"
+cmd_generate_integration_tests () {
+  declare steps_yaml
+  cases=('default' 'no_spire' 'tear_down')
+
+  for C in "${cases[@]}"; do
+    launch_cluster $C
+    steps_yaml+=("""
+  - label: \"integration test: $C\"
     commands:
       - scripts/cibuild wait_for_k3s
       - buildkite-agent artifact download \"${BUILDKITE_PIPELINE_SLUG}_${BUILDKITE_BUILD_NUMBER}.tar\" /tmp/
       - mv /tmp/\"${BUILDKITE_PIPELINE_SLUG}_${BUILDKITE_BUILD_NUMBER}.tar\" /opt/k3s-import/
-      - ( cd pkg/cuemodule && cue eval -c ./k8s/outputs -t operator_image='docker.greymatter.io/development/gm-operator:latest' --out text -e operator_manifests_yaml | kubectl apply -f - )
+      - k3s kubectl create namespace gm-operator
       - scripts/cibuild create_image_pull_secret gm-docker-secret gm-operator
-      # TODO remove this sleep
-      - sleep 500
-      # - k3s kubectl get pods -A
-      # - KUBECTL_CMD='k3s kubectl' ./scripts/test crd
+      - sleep 5
+      - KUBECTL_CMD='k3s kubectl' ./scripts/test integration $C
       - k3s kubectl get pods -A
-      - k3s kubectl logs -n gm-operator sts/gm-operator
       - sudo systemctl poweroff
     agents:
       buildkite_build_number: $BUILDKITE_BUILD_NUMBER
       buildkite_pipeline_slug: $BUILDKITE_PIPELINE_SLUG
-
-"
+      integration_test_case: $C""")
+  done
+  echo "
+steps: ${steps_yaml[@]}
+  " | buildkite-agent pipeline upload
 }
 
-cmd_launch_k3s () {
+# Sends a POST request to a relay.sh webhook which triggers a process to spin up k3s cluster running on an ec2
+launch_cluster () {
   # The tags payload will set EC2 tags that should be picked up by buildkite-agent
   # running in the new EC2.
-  curl -X POST \
-    -d "{ \"tags\": { \"buildkite_pipeline_slug\": \"$BUILDKITE_PIPELINE_SLUG\", \"buildkite_build_number\": \"$BUILDKITE_BUILD_NUMBER\" }}" \
-    "$RELAYSH_LAUNCH_K3S_EC2_WEBHOOK" 
+  test_case=$1
+  curl -sSL -X POST \
+    -d "{ \"tags\": { \"buildkite_pipeline_slug\": \"$BUILDKITE_PIPELINE_SLUG\", \"buildkite_build_number\": \"$BUILDKITE_BUILD_NUMBER\", \"integration_test_case\": \"$test_case\"}}" \
+    "$RELAYSH_LAUNCH_K3S_EC2_WEBHOOK"
 }
 
+# Releases the docker iamge and binaries if pipeline is running in the correct context
 cmd_release () {
   _release_container
   _release_bundle
@@ -140,7 +157,7 @@ fi
 CMD=$1
 shift
 case $CMD in
-  test|build|release|launch_k3s|generate_integration_pipeline|wait_for_k3s|export_container|create_image_pull_secret)
+  test|build|release|generate_integration_tests|wait_for_k3s|export_container|create_image_pull_secret|bootstrap)
     cmd_$CMD $@
     ;;
   *)

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -103,7 +103,6 @@ _release_bundle() {
 
 # Creates the dynamic pipeline that starts up the greymatter mesh environment
 #  in the ephemeral ec2s. The output of the echo commands runs on the ec2, not the original machine running the rest of the pipeline.
-
 cmd_generate_integration_tests () {
   declare steps_yaml
   cases=('default' 'no_spire' 'tear_down')

--- a/scripts/test
+++ b/scripts/test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-
+# an associative array mapping service name to k8s selector - this allows for querying without needing the pod name
 declare -A pods=( [control]='greymatter.io/cluster=controlensemble' [catalog]='greymatter.io/cluster=catalog' [edge]='greymatter.io/cluster=edge' \
     [redis]='greymatter.io/cluster=redis' [dashboard]='greymatter.io/cluster=dashboard' [edge svc]=' app=svclb-edge')
 
@@ -18,6 +18,7 @@ test_help () {
   echo "  ./scripts/test [help|fast|lint|crd]"
 }
 
+# Polls a pod for a ready status. Errors on timeout
 _wait_for_resouce() {
   selector=$1
   namespace=$2
@@ -37,16 +38,18 @@ _wait_for_resouce() {
   done
 }
 
+# A helper function     Installs the operator with provided tags
 install_operator () {
   tags=$1
-  ( cd pkg/cuemodule && cue eval -c ./k8s/outputs -t operator_image='docker.greymatter.io/development/gm-operator:latest' $tags  --out text -e operator_manifests_yaml | kubectl apply -f - )
+  ( cd pkg/cuemodule && cue eval -c ./k8s/outputs -t operator_image='docker.greymatter.io/development/gm-operator:latest' $tags  --out text -e operator_manifests_yaml | $KUBECTL_CMD apply -f - )
 }
 
+#  A test case.   Asserts there are no mesh CRs present
 test_no_mesh() {
   echo "===> Test Case ${FUNCNAME[0]}"
 
   if [ $($KUBECTL_CMD get -n greymatter Mesh -o=jsonpath='{.items}' | jq 'length') -gt 0 ]; then
-    echo "TEST ${FUNCNAME[0]} FAILED: Mesh CRD exists"
+    echo "TEST ${FUNCNAME[0]} FAILED: Mesh CR exists"
     exit 1
   fi
 
@@ -54,6 +57,7 @@ test_no_mesh() {
   echo "Test ${FUNCNAME[0]}............PASSED"
 }
 
+#  A test case.   Manually installs a mesh, removes it, and installs another to test correct lifecycle behavior
 test_install_remove_mesh () {
   echo "===> Test Case ${FUNCNAME[0]}"
 
@@ -74,6 +78,8 @@ spec:
 
   test_reachable_mesh
 
+  # spawn jobs in the background for each wait command and keep track of their pid
+ 
   pids=()
   for pod in "${!pods[@]}"; do
     $KUBECTL_CMD wait pod --for=delete --timeout=120s --selector ${pods[$pod]} &
@@ -81,8 +87,9 @@ spec:
   done
   $KUBECTL_CMD wait namespace/greymatter --for=delete --timeout=120s &
   pids+=($!)
-
+ # We start waiting for k8s to delete resources before we delete the mesh since kubectl wait must have a resource available
   $KUBECTL_CMD delete Mesh mesh-sample
+  # wait will return error codes if the pids are explicitly listed
   wait "${pids[@]}"
 
   if [ $? -gt 0 ]; then
@@ -90,6 +97,8 @@ spec:
   fi
 
   test_no_mesh
+
+  # Now that a mesh was created and destroyed, create another one
 
     echo """
 apiVersion: greymatter.io/v1alpha1
@@ -115,6 +124,7 @@ spec:
   echo "Test ${FUNCNAME[0]}............PASSED"
 }
 
+#  A test case.   Checks if spire is running on the cluster, fail if it is
 test_no_spire() {
   echo "===> Test Case ${FUNCNAME[0]}"
 
@@ -129,12 +139,14 @@ test_no_spire() {
   echo "Test ${FUNCNAME[0]}............PASSED"
 }
 
+#  A test case.   Checks operator installation completes before timeout
 test_operator_install() {
   echo "==> Test Case ${FUNCNAME[0]}"
 
   echo "Waiting for operator..."
   _wait_for_resouce 'name=gm-operator' 'gm-operator' &
 
+  # $! = pid of last bg job
   wait $!
 
   if [ $? -gt 0 ]; then
@@ -142,6 +154,7 @@ test_operator_install() {
     exit 1
   fi
 
+  # save and upload logs
   $KUBECTL_CMD logs -n gm-operator sts/gm-operator > operator_logs.txt 
   buildkite-agent artifact upload operator_logs.txt
 
@@ -149,6 +162,7 @@ test_operator_install() {
   echo "Test ${FUNCNAME[0]}............PASSED"
 }
 
+#  A test case.   Checks if all gm services start before a timeout
 test_mesh_startup() {
   echo "==> Test Case ${FUNCNAME[0]}"
 
@@ -170,7 +184,10 @@ test_mesh_startup() {
   echo "Test ${FUNCNAME[0]}............PASSED"
 }
 
+# A test case.   Checks the network accesibility of gm services
 test_reachable_mesh() {
+  # Runs curl in a retry loop. GM services have a slight lag between when the pod is ready and when proxies accept connections
+  # curl --retry et al is not robust enough for the tests
   curl_retry() {
     url=$1
     timeout=120
@@ -182,6 +199,7 @@ test_reachable_mesh() {
         return 1
       fi
 
+      # use ipv4, suppress output, fail on all error codes, and show header info
       result=$(curl -4 -sSLf -D - -o /dev/null $url)
       err=$?
       if [ $err -gt 0 ]; then
@@ -196,7 +214,9 @@ test_reachable_mesh() {
 
   echo "==> Test Case ${FUNCNAME[0]}"
 
+  # ingress port is dynamic
   PORT=$(kubectl get -n greymatter svc --output=jsonpath="{.spec.ports[0].nodePort}" edge)
+
   echo
   echo "Trying Dashboard..."
 
@@ -211,8 +231,9 @@ test_reachable_mesh() {
   
   echo
   echo "Trying control..."
+
+  # Check if control sends JSON; gives us better assurance that the response was correct
   res=$( curl_retry "http://localhost:$PORT/services/control-api/v1.0/zone")
-  echo $res
   echo $res | grep -q "content-type: application/json"
   if [ $? -gt 0 ]; then
     echo "TEST ${FUNCNAME[0]} FAILED."
@@ -223,6 +244,7 @@ test_reachable_mesh() {
 
   echo
   echo "Trying Catalog..."
+
   res=$( curl_retry "http://localhost:$PORT/services/catalog/summary")
   echo $res | grep -q 'content-type: application/json'
   if [ $? -gt 0 ]; then
@@ -236,6 +258,7 @@ test_reachable_mesh() {
   echo "Test ${FUNCNAME[0]}............PASSED"
 }
 
+# Integration test "dispatcher" function
 test_integration() {
   TEST=$1
   case $TEST in

--- a/scripts/test
+++ b/scripts/test
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -e
+
+declare -A pods=( [control]='greymatter.io/cluster=controlensemble' [catalog]='greymatter.io/cluster=catalog' [edge]='greymatter.io/cluster=edge' \
+    [redis]='greymatter.io/cluster=redis' [dashboard]='greymatter.io/cluster=dashboard' [edge svc]=' app=svclb-edge')
 
 test_lint () {
   staticcheck ./...
@@ -16,14 +18,46 @@ test_help () {
   echo "  ./scripts/test [help|fast|lint|crd]"
 }
 
-# This command expects the greymatter namespace to exist
-# and the image pull secret to be created.
-test_crd () {
-  if [[ -z $KUBECTL_CMD ]]; then
-    echo "defaulting KUBECTL_CMD to \"kubectl\""
-    KUBECTL_CMD="kubectl"
+_wait_for_resouce() {
+  selector=$1
+  namespace=$2
+  timeout=$3
+  if [ -z $3 ]; then
+    timeout=300
   fi
-  echo "
+
+  while [ "$($KUBECTL_CMD get -n ${namespace} pods --selector ${selector} -o jsonpath='{.items[*].status.containerStatuses[0].ready}')" != "true" ]; do
+    if [ $timeout -eq 0 ]; then
+      echo "Failed while waiting for ${pod}: pod timed out"
+      exit 1
+    fi
+
+    timeout=$(($timeout-5))
+    sleep 5
+  done
+}
+
+install_operator () {
+  tags=$1
+  ( cd pkg/cuemodule && cue eval -c ./k8s/outputs -t operator_image='docker.greymatter.io/development/gm-operator:latest' $tags  --out text -e operator_manifests_yaml | kubectl apply -f - )
+}
+
+test_no_mesh() {
+  echo "===> Test Case ${FUNCNAME[0]}"
+
+  if [ $($KUBECTL_CMD get -n greymatter Mesh -o=jsonpath='{.items}' | jq 'length') -gt 0 ]; then
+    echo "TEST ${FUNCNAME[0]} FAILED: Mesh CRD exists"
+    exit 1
+  fi
+
+  echo
+  echo "Test ${FUNCNAME[0]}............PASSED"
+}
+
+test_install_remove_mesh () {
+  echo "===> Test Case ${FUNCNAME[0]}"
+
+  echo """
 apiVersion: greymatter.io/v1alpha1
 kind: Mesh
 metadata:
@@ -33,23 +67,213 @@ spec:
   zone: default-zone
   install_namespace: greymatter
   watch_namespaces:
-    - default
-  image_pull_secrets:
-    - gm-docker-secret
-  images:
-    control: docker.greymatter.io/development/gm-control:latest
-" | $KUBECTL_CMD apply -f -
+  - default
+""" | $KUBECTL_CMD apply -f -
 
-  sleep 10
-  echo "Waiting for gm-control"
-  set +e
-  $KUBECTL_CMD wait --namespace greymatter --for condition=ready pod \
-    --selector "greymatter.io/component=control" --timeout 120s
-  set -e
-  echo "Final pod list"
-  $KUBECTL_CMD get pods -A
+  test_mesh_startup
 
+  test_reachable_mesh
+
+  pids=()
+  for pod in "${!pods[@]}"; do
+    $KUBECTL_CMD wait pod --for=delete --timeout=120s --selector ${pods[$pod]} &
+    pids+=($!)
+  done
+  $KUBECTL_CMD wait namespace/greymatter --for=delete --timeout=120s &
+  pids+=($!)
+
+  $KUBECTL_CMD delete Mesh mesh-sample
+  wait "${pids[@]}"
+
+  if [ $? -gt 0 ]; then
+    echo "TEST ${FUNCNAME[0]} FAILED: pods were not cleaned up after mesh teardown"
+  fi
+
+  test_no_mesh
+
+    echo """
+apiVersion: greymatter.io/v1alpha1
+kind: Mesh
+metadata:
+  name: new-mesh
+spec:
+  release_version: '1.7'
+  zone: default-zone
+  install_namespace: greymatter
+  watch_namespaces:
+  - default
+""" | $KUBECTL_CMD apply -f -
+
+  $KUBECTL_CMD get -n greymatter Mesh | grep -q "new-mesh"
+  if [ $? -gt 0 ]; then
+    echo "TEST ${FUNCNAME[0]} FAILED: new mesh resource not found"
+    exit 1
+  fi
+  test_mesh_startup
+
+  echo
+  echo "Test ${FUNCNAME[0]}............PASSED"
 }
+
+test_no_spire() {
+  echo "===> Test Case ${FUNCNAME[0]}"
+
+  $KUBECTL_CMD get pods -A | grep -q "spire"
+
+  if [ $? -eq 0 ]; then
+    echo "TEST ${FUNCNAME[0]} FAILED: spire installation was detected"
+    exit 1
+  fi
+
+  echo
+  echo "Test ${FUNCNAME[0]}............PASSED"
+}
+
+test_operator_install() {
+  echo "==> Test Case ${FUNCNAME[0]}"
+
+  echo "Waiting for operator..."
+  _wait_for_resouce 'name=gm-operator' 'gm-operator' &
+
+  wait $!
+
+  if [ $? -gt 0 ]; then
+    echo "TEST ${FUNCNAME[0]} FAILED. \noperator install: timed out"
+    exit 1
+  fi
+
+  $KUBECTL_CMD logs -n gm-operator sts/gm-operator > operator_logs.txt 
+  buildkite-agent artifact upload operator_logs.txt
+
+  echo
+  echo "Test ${FUNCNAME[0]}............PASSED"
+}
+
+test_mesh_startup() {
+  echo "==> Test Case ${FUNCNAME[0]}"
+
+  declare pids=()
+
+  for pod in "${!pods[@]}"; do
+    echo "Waiting for ${pod}..."
+    _wait_for_resouce ${pods[$pod]} 'greymatter' &
+    pids+=($!)
+  done
+  wait "${pids[@]}"
+
+  if [ $? -gt 0 ];  then
+    echo "TEST ${FUNCNAME[0]} FAILED"
+    exit 1
+  fi
+
+  echo
+  echo "Test ${FUNCNAME[0]}............PASSED"
+}
+
+test_reachable_mesh() {
+  curl_retry() {
+    url=$1
+    timeout=120
+    retry="true"
+    result=""
+    while [ $retry = "true" ]; do
+      if [ $timeout -eq 0 ]; then
+        echo "could not reach $url: timed out"
+        return 1
+      fi
+
+      result=$(curl -4 -sSLf -D - -o /dev/null $url)
+      err=$?
+      if [ $err -gt 0 ]; then
+        sleep 10
+        timeout=$(($timeout-10))
+      else 
+        retry="false"
+      fi
+    done
+    echo $result
+  }
+
+  echo "==> Test Case ${FUNCNAME[0]}"
+
+  PORT=$(kubectl get -n greymatter svc --output=jsonpath="{.spec.ports[0].nodePort}" edge)
+  echo
+  echo "Trying Dashboard..."
+
+  curl_retry "http://localhost:$PORT"
+  if [ $? -gt 0 ]; then
+    echo "TEST ${FUNCNAME[0]} FAILED."
+    echo "An error occured while attempting to access the dashboard"
+    exit 1
+  fi
+
+  echo "Successfully reached Dashboard"
+  
+  echo
+  echo "Trying control..."
+  res=$( curl_retry "http://localhost:$PORT/services/control-api/v1.0/zone")
+  echo $res
+  echo $res | grep -q "content-type: application/json"
+  if [ $? -gt 0 ]; then
+    echo "TEST ${FUNCNAME[0]} FAILED."
+    echo "Control was unreachable or did not return the correct response from GET /zone"
+    exit 1
+  fi
+  echo "Successfully reached Control"
+
+  echo
+  echo "Trying Catalog..."
+  res=$( curl_retry "http://localhost:$PORT/services/catalog/summary")
+  echo $res | grep -q 'content-type: application/json'
+  if [ $? -gt 0 ]; then
+    echo "TEST ${FUNCNAME[0]} FAILED."
+    echo "Catalog was unreachable or did not return the correct response from GET /summary"
+    exit 1
+  fi
+  echo "Successfully reached Catalog"
+
+  echo
+  echo "Test ${FUNCNAME[0]}............PASSED"
+}
+
+test_integration() {
+  TEST=$1
+  case $TEST in
+    default)
+      install_operator
+      test_operator_install
+      test_mesh_startup
+      test_reachable_mesh
+      ;;
+    no_spire)
+      install_operator "-t spire=false"
+      test_operator_install
+      test_no_spire
+      test_mesh_startup
+      test_reachable_mesh
+      ;;
+    tear_down)
+      install_operator "-t auto_apply_mesh=false"
+      test_operator_install
+      test_no_mesh
+      test_install_remove_mesh
+      # TODO: re-instate after config refresh bug is fixed
+      # test_reachable_mesh
+    ;;
+    *) 
+      echo "invalid argument $TEST"
+      exit 1
+      ;;
+  esac
+
+  echo
+  echo "ALL TESTS COMPLETED"
+}
+
+if [[ -z $KUBECTL_CMD ]]; then
+    echo "defaulting KUBECTL_CMD to \"kubectl\""
+    KUBECTL_CMD="kubectl"
+fi
 
 if [ $# -eq 0 ]; then
   test_fast
@@ -57,7 +281,7 @@ else
   ARG=$1
   shift
   case $ARG in
-  crd|lint|fast|help)
+  crd|lint|fast|integration|help)
     test_$ARG $@
     ;;
   *)

--- a/scripts/test
+++ b/scripts/test
@@ -20,15 +20,20 @@ test_help () {
 
 # Polls a pod for a ready status. Errors on timeout
 _wait_for_resouce() {
-  selector=$1
-  namespace=$2
-  timeout=$3
+  # technically only waits for a pod but can be extended easily by accepting a resource type argument. This function 
+  # imitates the kubectl wait command, except it will not fail if there does not exist a pod with a matching selector. 
+  # This is useful in our case since we often want to wait for resources which may not be present at the exact moment of the function
+  #  call, but will be present some small but indeterminate amount of time later
+  
+  local selector=$1
+  local namespace=$2
+  local timeout=$3
   if [ -z $3 ]; then
     timeout=300
   fi
 
   while [ "$($KUBECTL_CMD get -n ${namespace} pods --selector ${selector} -o jsonpath='{.items[*].status.containerStatuses[0].ready}')" != "true" ]; do
-    if [ $timeout -eq 0 ]; then
+    if [ $timeout -le 0 ]; then
       echo "Failed while waiting for ${pod}: pod timed out"
       exit 1
     fi
@@ -38,14 +43,17 @@ _wait_for_resouce() {
   done
 }
 
-# A helper function     Installs the operator with provided tags
+# A helper function     Evaluates the CUE files to install the operator, overriding the config definitions with the values found in the tags
 install_operator () {
-  tags=$1
+  local tags=$1
   ( cd pkg/cuemodule && cue eval -c ./k8s/outputs -t operator_image='docker.greymatter.io/development/gm-operator:latest' $tags  --out text -e operator_manifests_yaml | $KUBECTL_CMD apply -f - )
 }
 
 #  A test case.   Asserts there are no mesh CRs present
 test_no_mesh() {
+  # get the mesh crs from kubectl and check the items array. if the length is greater than 0, then there is at least 1 mesh installed
+  # and the test fails
+
   echo "===> Test Case ${FUNCNAME[0]}"
 
   if [ $($KUBECTL_CMD get -n greymatter Mesh -o=jsonpath='{.items}' | jq 'length') -gt 0 ]; then
@@ -59,13 +67,21 @@ test_no_mesh() {
 
 #  A test case.   Manually installs a mesh, removes it, and installs another to test correct lifecycle behavior
 test_install_remove_mesh () {
+# This test should run with the auto_apply_mesh operator config option set to false and assumes the operator is ready. It first
+# creates a mesh custom resource by applying the mesh resource yaml definition on the k3s cluster
+# The operator will detect the creation of the object and spin up the gm service. The test waits for those services to come online
+# before testing their accessibility. Both checks are used in other test cases. If those succeed, then the test moves to the tear down.
+# Using the kubectl wait command, each gm sevice is waited upon in the background until it is deleted. After sending out the background jobs
+# the test deletes the mesh cr and waits for every job to finish. The test then repeats the process of creating a mesh, this time, with a different name
+# to check if the operator works correctly when dealing with a fresh install in a non-fresh cluster.
+
   echo "===> Test Case ${FUNCNAME[0]}"
 
   echo """
 apiVersion: greymatter.io/v1alpha1
 kind: Mesh
 metadata:
-  name: mesh-sample
+  name: mesh-1
 spec:
   release_version: '1.7'
   zone: default-zone
@@ -80,7 +96,7 @@ spec:
 
   # spawn jobs in the background for each wait command and keep track of their pid
  
-  pids=()
+  local pids=()
   for pod in "${!pods[@]}"; do
     $KUBECTL_CMD wait pod --for=delete --timeout=120s --selector ${pods[$pod]} &
     pids+=($!)
@@ -104,7 +120,7 @@ spec:
 apiVersion: greymatter.io/v1alpha1
 kind: Mesh
 metadata:
-  name: new-mesh
+  name: mesh-2
 spec:
   release_version: '1.7'
   zone: default-zone
@@ -126,10 +142,14 @@ spec:
 
 #  A test case.   Checks if spire is running on the cluster, fail if it is
 test_no_spire() {
+  # This test runs when no-spire operator config value is set to true. When the operator deploys, it will immediately start spire in its own namespace
+  # The spire deployment will consist of just the agent and the server. The test simply checks for the existence of spire in the cluster by listing all
+  # pods across all namespaces and searching the output for the string 'spire'. grep -q will return an exit code of 0 if it found a match or a 1 if it did not.
+
   echo "===> Test Case ${FUNCNAME[0]}"
 
   $KUBECTL_CMD get pods -A | grep -q "spire"
-
+  # We do NOT want a match -- match == 0 , then log error
   if [ $? -eq 0 ]; then
     echo "TEST ${FUNCNAME[0]} FAILED: spire installation was detected"
     exit 1
@@ -141,21 +161,22 @@ test_no_spire() {
 
 #  A test case.   Checks operator installation completes before timeout
 test_operator_install() {
+  # Tests whether the operator pod reports a ready status within a time period. The wait_for_resource function allows for a optimized 
+  # waiting scheme by polling the kubectl for pod statuses every 5 seconds. If the timeout occurs, then there is probably something wrong with the operator
+
   echo "==> Test Case ${FUNCNAME[0]}"
 
   echo "Waiting for operator..."
-  _wait_for_resouce 'name=gm-operator' 'gm-operator' &
-
-  # $! = pid of last bg job
-  wait $!
+  _wait_for_resouce 'name=gm-operator' 'gm-operator'
 
   if [ $? -gt 0 ]; then
-    echo "TEST ${FUNCNAME[0]} FAILED. \noperator install: timed out"
+    echo "TEST ${FUNCNAME[0]} FAILED."
+    echo "operator install: timed out"
     exit 1
   fi
 
   # save and upload logs
-  $KUBECTL_CMD logs -n gm-operator sts/gm-operator > operator_logs.txt 
+  $KUBECTL_CMD logs -n gm-operator sts/gm-operator > operator_logs.txt
   buildkite-agent artifact upload operator_logs.txt
 
   echo
@@ -164,6 +185,11 @@ test_operator_install() {
 
 #  A test case.   Checks if all gm services start before a timeout
 test_mesh_startup() {
+  # This test starts by iterating over the service-to-selector mapping. For each mapping, spin off a background job which polls for the pod's readiness
+  # once all pods are ready (or timeout) the wait command finishes and exits with 0 if all jobs were successfuly, or 1 if one failed (timed out). Just like
+  # for the operator install, wait_for_resource is used instead of kubectl wait because the services don't get applied deterministically after the operator.
+  # After the test, we can assume that every gm service pod is ready and running.
+
   echo "==> Test Case ${FUNCNAME[0]}"
 
   declare pids=()
@@ -186,13 +212,19 @@ test_mesh_startup() {
 
 # A test case.   Checks the network accesibility of gm services
 test_reachable_mesh() {
-  # Runs curl in a retry loop. GM services have a slight lag between when the pod is ready and when proxies accept connections
-  # curl --retry et al is not robust enough for the tests
+  # The goal here is to not just trust that a pod was successfully configured just because it reports a ready status to k8s.
+  # The test curls gm service endpoints and checks their response codes and content-type (could test more in the future) to ensure that
+  # they are reachable. If they are reachable then we know they were probably configured correctly and their container has crashed
+  # or entered some bad state. The test is simple, grab the dynamcially set ingress port, and just curl catalog, dashboard, and control. Curl will return a non-zero
+  # exit code if the request fails (5XX, 4XX, or closed socket). Grep is used to match simple strings in the headers.
+
   curl_retry() {
-    url=$1
-    timeout=120
-    retry="true"
-    result=""
+    # Runs curl in a retry loop. GM services have a slight lag between when the pod is ready and when proxies accept connections
+    # curl --retry (and its options) is not robust enough for our needs
+    local url=$1
+    local timeout=120
+    local retry="true"
+    local result=""
     while [ $retry = "true" ]; do
       if [ $timeout -eq 0 ]; then
         echo "could not reach $url: timed out"
@@ -215,12 +247,12 @@ test_reachable_mesh() {
   echo "==> Test Case ${FUNCNAME[0]}"
 
   # ingress port is dynamic
-  PORT=$(kubectl get -n greymatter svc --output=jsonpath="{.spec.ports[0].nodePort}" edge)
+  local port=$(kubectl get -n greymatter svc --output=jsonpath="{.spec.ports[0].nodePort}" edge)
 
   echo
   echo "Trying Dashboard..."
 
-  curl_retry "http://localhost:$PORT"
+  curl_retry "http://localhost:$port"
   if [ $? -gt 0 ]; then
     echo "TEST ${FUNCNAME[0]} FAILED."
     echo "An error occured while attempting to access the dashboard"
@@ -233,7 +265,7 @@ test_reachable_mesh() {
   echo "Trying control..."
 
   # Check if control sends JSON; gives us better assurance that the response was correct
-  res=$( curl_retry "http://localhost:$PORT/services/control-api/v1.0/zone")
+  local res=$( curl_retry "http://localhost:$port/services/control-api/v1.0/zone")
   echo $res | grep -q "content-type: application/json"
   if [ $? -gt 0 ]; then
     echo "TEST ${FUNCNAME[0]} FAILED."
@@ -245,7 +277,7 @@ test_reachable_mesh() {
   echo
   echo "Trying Catalog..."
 
-  res=$( curl_retry "http://localhost:$PORT/services/catalog/summary")
+  res=$( curl_retry "http://localhost:$port/services/catalog/summary")
   echo $res | grep -q 'content-type: application/json'
   if [ $? -gt 0 ]; then
     echo "TEST ${FUNCNAME[0]} FAILED."
@@ -260,8 +292,15 @@ test_reachable_mesh() {
 
 # Integration test "dispatcher" function
 test_integration() {
-  TEST=$1
-  case $TEST in
+  # This function is responsible for mapping integration tests commands to the corresponding barrage of tests and also for 
+  # making any configuration changes to the operator.
+  # default: just install the operator without changing any configuration options.
+  # no_spire: install the operator with spire disabled
+  # tear down: install the operator without automatically applying the mesh cr, manually apply one ourselves
+  #             delete it, and then create another one. 
+
+  local test=$1
+  case $test in
     default)
       install_operator
       test_operator_install
@@ -283,7 +322,7 @@ test_integration() {
       # TODO: re-instate after config refresh bug is fixed
       # test_reachable_mesh
     ;;
-    *) 
+    *)
       echo "invalid argument $TEST"
       exit 1
       ;;

--- a/scripts/test
+++ b/scripts/test
@@ -104,7 +104,7 @@ spec:
   $KUBECTL_CMD wait namespace/greymatter --for=delete --timeout=120s &
   pids+=($!)
  # We start waiting for k8s to delete resources before we delete the mesh since kubectl wait must have a resource available
-  $KUBECTL_CMD delete Mesh mesh-sample
+  $KUBECTL_CMD delete Mesh mesh-1
   # wait will return error codes if the pids are explicitly listed
   wait "${pids[@]}"
 
@@ -129,7 +129,7 @@ spec:
   - default
 """ | $KUBECTL_CMD apply -f -
 
-  $KUBECTL_CMD get -n greymatter Mesh | grep -q "new-mesh"
+  $KUBECTL_CMD get -n greymatter Mesh | grep -q "mesh-2"
   if [ $? -gt 0 ]; then
     echo "TEST ${FUNCNAME[0]} FAILED: new mesh resource not found"
     exit 1

--- a/scripts/test
+++ b/scripts/test
@@ -19,7 +19,7 @@ test_help () {
 }
 
 # Polls a pod for a ready status. Errors on timeout
-_wait_for_resouce() {
+_wait_for_resource() {
   # technically only waits for a pod but can be extended easily by accepting a resource type argument. This function 
   # imitates the kubectl wait command, except it will not fail if there does not exist a pod with a matching selector. 
   # This is useful in our case since we often want to wait for resources which may not be present at the exact moment of the function
@@ -71,7 +71,7 @@ test_install_remove_mesh () {
 # creates a mesh custom resource by applying the mesh resource yaml definition on the k3s cluster
 # The operator will detect the creation of the object and spin up the gm service. The test waits for those services to come online
 # before testing their accessibility. Both checks are used in other test cases. If those succeed, then the test moves to the tear down.
-# Using the kubectl wait command, each gm sevice is waited upon in the background until it is deleted. After sending out the background jobs
+# Using the kubectl wait command, each gm service is waited upon in the background until it is deleted. After sending out the background jobs
 # the test deletes the mesh cr and waits for every job to finish. The test then repeats the process of creating a mesh, this time, with a different name
 # to check if the operator works correctly when dealing with a fresh install in a non-fresh cluster.
 
@@ -167,7 +167,7 @@ test_operator_install() {
   echo "==> Test Case ${FUNCNAME[0]}"
 
   echo "Waiting for operator..."
-  _wait_for_resouce 'name=gm-operator' 'gm-operator'
+  _wait_for_resource 'name=gm-operator' 'gm-operator'
 
   if [ $? -gt 0 ]; then
     echo "TEST ${FUNCNAME[0]} FAILED."
@@ -186,7 +186,7 @@ test_operator_install() {
 #  A test case.   Checks if all gm services start before a timeout
 test_mesh_startup() {
   # This test starts by iterating over the service-to-selector mapping. For each mapping, spin off a background job which polls for the pod's readiness
-  # once all pods are ready (or timeout) the wait command finishes and exits with 0 if all jobs were successfuly, or 1 if one failed (timed out). Just like
+  # once all pods are ready (or timeout) the wait command finishes and exits with 0 if all jobs were successfully, or 1 if one failed (timed out). Just like
   # for the operator install, wait_for_resource is used instead of kubectl wait because the services don't get applied deterministically after the operator.
   # After the test, we can assume that every gm service pod is ready and running.
 
@@ -196,7 +196,7 @@ test_mesh_startup() {
 
   for pod in "${!pods[@]}"; do
     echo "Waiting for ${pod}..."
-    _wait_for_resouce ${pods[$pod]} 'greymatter' &
+    _wait_for_resource ${pods[$pod]} 'greymatter' &
     pids+=($!)
   done
   wait "${pids[@]}"


### PR DESCRIPTION
Please see https://buildkite.com/greymatter/operator/builds/554 for the status of the tests.

This pr adds a few features. 
First, the wait times for async actions, like
installing the operator, are minimized by replacing estimated sleeps with
polling. Particularly, the wait_for_resource and curl_retry use polling with a
few second delay to effectively wait for pods and other resources to become
available and for servers to begin accepting requests, respectively.

Second, the pr adds stricter and more test assertions. These include actions like
testing for existence (and lack thereof) of pods, testing network
accessibility, and testing for readiness by a timeout (failing to be ready by a
timeout likely indicates an error as the timeouts are generous). 

Lastly, the pr expands the testing profile and facilitates future expansions by generating n pipelines and creating n k3s
clusters, where n is the number of operator tests or configurations which need
a clean machine. It does so by tagging the ec2 with the test name and including
that tag in the pipeline; an extension of the same pattern used to generate and
link just the one ec2.

There are currently three separate integration tests: one is a default installation, the other is a no spire installation, and the last creates and deletes mesh CRs to if creating meshes deploy the gm services properly and if deleting them destroys services properly.

Note, one test assertion was disabled for the tear down scenario due to a bug that Daniel may be working on. Once that fix gets merged in, then that test can be re-enabled. 