### PR TITLE
Pipeline releases only after integration tests succeed.

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -2,18 +2,16 @@ steps:
   - label: "run unit tests"
     agents:
       container_image: ubuntu-2110-ci
-    commands: 
+    commands:
       - ./scripts/cibuild bootstrap
       - ./scripts/cibuild test
-  - wait
-  - label: ":shipit: build and release"
+  - label: ":shipit: build"
     agents:
       container_image: ubuntu-2110-ci
     commands:
       - ./scripts/cibuild bootstrap
       - ./scripts/cibuild build
       - ./scripts/cibuild export_container "${BUILDKITE_PIPELINE_SLUG}_${BUILDKITE_BUILD_NUMBER}.tar" "docker.greymatter.io/development/gm-operator:latest"
-      - ./scripts/cibuild release
     retry:
       automatic:
         - exit_status: "*"
@@ -22,3 +20,6 @@ steps:
   - label: "run integration tests"
     commands:
       - ./scripts/cibuild generate_integration_tests
+  - wait
+  - label: "release"
+    command: "./scripts/cibuild release"

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -106,7 +106,6 @@ _release_bundle() {
 cmd_generate_integration_tests () {
   declare steps_yaml
   cases=('default' 'no_spire' 'tear_down')
-
   for C in "${cases[@]}"; do
     launch_cluster $C
     steps_yaml+=("""

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -65,10 +65,13 @@ _build_image () {
   buildah bud $build_args -t "${tag}" --layers -f ${dockerfile} .
 }
 
-# Logs into Nexus, checks if CI is running during a tag release or merge into main and if so pushes assets
+# Logs into Nexus, checks if CI is running during a tag release or merge into main and if so pushes assets. 
+# Needs to download the previous assets in case the agent machine gets reassigned (in which case the build assets won't be there)
 _release_container () {
-  container-registry-login $NEXUS_USER $NEXUS_PASS
   local latest="docker.greymatter.io/development/gm-operator:latest"
+  buildkite-agent artifact download "${BUILDKITE_PIPELINE_SLUG}_${BUILDKITE_BUILD_NUMBER}.tar" . --build ${BUILDKITE_BUILD_ID} --agent-access-token ${BUILDKITE_AGENT_ACCESS_TOKEN}
+  podman load -q -i "${BUILDKITE_PIPELINE_SLUG}_${BUILDKITE_BUILD_NUMBER}.tar"
+  container-registry-login $NEXUS_USER $NEXUS_PASS
   if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
     container-registry-push $latest
   fi
@@ -106,6 +109,7 @@ _release_bundle() {
 cmd_generate_integration_tests () {
   declare steps_yaml
   cases=('default' 'no_spire' 'tear_down')
+
   for C in "${cases[@]}"; do
     launch_cluster $C
     steps_yaml+=("""


### PR DESCRIPTION
The CI process shouldn't release binaries or containers if the integration tests (or any tests) fail. This pr fixes that issue by breaking out the release command into its own step, where with the buildkite wait command, will run only if the previous step succeeds. 