### PR TITLE
Fixing business impact and config inspection by pointing dashboard to the right place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
 - Cleaned up unnecessary SPIRE agent unix workload attestor configuration.
 - Fixed family of issues that prevented the operator from restarting cleanly. The Operator now
   reloads the list of sidecars used for Spire mTLS authorization from the Mesh CR itself.
+- Fixed control-api URL in dashboard so that proxy config inspection and business impact selection
+  would work from the UI.
 
 ## 0.3.3 (February 10, 2022)
 

--- a/pkg/cuemodule/gm/outputs/catalogentries.cue
+++ b/pkg/cuemodule/gm/outputs/catalogentries.cue
@@ -44,7 +44,7 @@ catalog_entries: [
 	  service_id: "controlensemble"
 		version:         strings.Split(mesh.spec.images.control_api, ":")[1]
 		description:       "Manages the configuration of the Grey Matter data plane."
-		api_endpoint:      "/services/control-api/v1.0/"
+		api_endpoint:      "/services/control-api/"
 		business_impact:   "critical"
 		api_spec_endpoint: "/services/control-api/"
 		enable_instance_metrics: true

--- a/pkg/cuemodule/k8s/outputs/dashboard.cue
+++ b/pkg/cuemodule/k8s/outputs/dashboard.cue
@@ -37,7 +37,7 @@ dashboard: [
               env: [
                 {name: "BASE_URL", value: "/services/\(name)/"},
                 {name: "FABRIC_SERVER", value: "/services/catalog/"},
-                {name: "CONFIG_SERVER", value: "/services/control-api/"},
+                {name: "CONFIG_SERVER", value: "/services/control-api/v1.0"},
                 {name: "PROMETHEUS_SERVER", value: "/services/prometheus/api/v1/"},
                 {name: "REQUEST_TIMEOUT", value: "15000"},
                 {name: "USE_PROMETHEUS", value: "false"},


### PR DESCRIPTION
Fixes [sc-13236], [sc-13302], [sc-10560] by setting the correct control-api URL in the Dashboard's CONFIG_SERVER environment variable and Control API's Catalog entry.

To test: Do the Getting Started into a fresh reset of Rancher Desktop, then open one of the card's side panels and confirm you can change business impacts, and click the 'Grey Matter-DP' button.