### PR TITLE
Bugfix: Don't inject sidecar in unwatched namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ If you would like to attach a remote debugger to your operator container, do the
 scripts/build debug_container
 
 # Push the image you just built to Nexus
-docker push docker.greymatter.io/internal/gm-operator:debug
+docker push docker.greymatter.io/internal/gm-operator:latest-debug
 
 # Launch the operator with the debug build in debug mode.
 # Note the two tags (`operator_image` and `debug`) which are the only differences from Getting Started
 ( 
 cd pkg/cuemodule
 cue eval -c ./k8s/outputs --out text \
-         -t operator_image=docker.greymatter.io/internal/gm-operator:debug \
+         -t operator_image=docker.greymatter.io/internal/gm-operator:latest-debug \
          -t debug=true \
          -e operator_manifests_yaml | kubectl apply -f -
 

--- a/scripts/build
+++ b/scripts/build
@@ -47,17 +47,17 @@ _docker_build () {
 
 cmd_container () {
   if type -p buildah  &>/dev/null; then
-    _buildah_build "docker.greymatter.io/internal/gm-operator:latest" Dockerfile
+    _buildah_build "docker.greymatter.io/internal/gm-operator:latest" "Dockerfile"
   else
-    _docker_build "docker.greymatter.io/internal/gm-operator:latest" Dockerfile
+    _docker_build "docker.greymatter.io/internal/gm-operator:latest" "Dockerfile"
   fi
 }
 
 cmd_debug_container () {
   if type -p buildah  &>/dev/null; then
-    _buildah_build "docker.greymatter.io/internal/gm-operator:latest-debug" Dockerfile.debug
+    _buildah_build "docker.greymatter.io/internal/gm-operator:latest-debug" "Dockerfile.debug"
   else
-    _docker_build "docker.greymatter.io/internal/gm-operator:latest-debug" Dockerfile.debug
+    _docker_build "docker.greymatter.io/internal/gm-operator:latest-debug" "Dockerfile.debug"
   fi
 }
 


### PR DESCRIPTION
[sc-13384]

Turns out I just wasn’t even checking that the pod was in the watched namespaces before injecting a sidecar, so… easy fix.

Also includes a minor fix to the debug build script and instructions.

If you want to test this, follow the Getting Started instructions in the README, then deploy a workload into a _watched_ namespace (the default mesh watches only the `default` namespace) and another into an _unwatched_ namespace. A sidecar should be injected into the former (and configured) but not the latter.