### PR TITLE
Build operator installation manifests

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -12,6 +12,7 @@ steps:
       - ./scripts/cibuild bootstrap
       - ./scripts/cibuild build
       - ./scripts/cibuild export_container "${BUILDKITE_PIPELINE_SLUG}_${BUILDKITE_BUILD_NUMBER}.tar" "docker.greymatter.io/development/gm-operator:latest"
+      - ./scripts/cibuild export_manifests "${BUILDKITE_PIPELINE_SLUG}_${BUILDKITE_BUILD_NUMBER}_manifests.tar.gz"
     retry:
       automatic:
         - exit_status: "*"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Manifests to be published
+manifests/*
 
 # Binaries for programs and plugins
 *.exe

--- a/pkg/cuemodule/inputs.cue
+++ b/pkg/cuemodule/inputs.cue
@@ -10,7 +10,7 @@ import (
 
 config: {
   // Flags
-  spire: bool | *true @tag(spire,type=bool) // enable Spire-based mTLS DEBUG - the default should be false
+  spire: bool | *false @tag(spire,type=bool) // enable Spire-based mTLS
   auto_apply_mesh: bool | *true @tag(auto_apply_mesh,type=bool) // apply the default mesh specified above after a delay
 
   debug: bool | *false @tag(debug,type=bool) // currently just controls k8s/outputs/operator.cue for debugging
@@ -61,8 +61,7 @@ defaults: {
   }
 
   images: {
-    // TODO this is not the default image we actually want for 1.0, so update this later
-    operator: string | *"docker.greymatter.io/internal/gm-operator:local_refactored" @tag(operator_image) // cibuild uses the tag
+    operator: string | *"docker.greymatter.io/internal/gm-operator:latest" @tag(operator_image) // cibuild uses the tag
   }
 
 }

--- a/scripts/build
+++ b/scripts/build
@@ -3,7 +3,7 @@
 # Builds a local, native build by default
 # Can build a container build if passed appropriate args
 
-set -euf -o pipefail
+set -eu -o pipefail
 
 cmd_build () {
   if [[ $OSTYPE == 'linux-gnu' ]]
@@ -22,7 +22,7 @@ cmd_debug () {
 }
 
 cmd_help () {
-  echo 'valid args: container, debug_container, build, help'
+  echo 'valid args: container, debug_container, build, debug, manifests, help'
 }
 
 _buildah_build () {
@@ -61,6 +61,39 @@ cmd_debug_container () {
   fi
 }
 
+cmd_manifests () {
+  local version="v1.0"
+  local location="manifests/${version}"
+
+  echo "Deleting old manifests for version ${version}..."
+  \rm -rf manifests/ || echo "No old manifests to delete."
+  mkdir -p "$location"
+  echo "Generating new manifests into ${location}"
+  (
+  cd pkg/cuemodule
+  # Defaults (spire off and auto-applies a mesh)
+  cue eval -c ./k8s/outputs \
+           --out text \
+           -e operator_manifests_yaml > ../../${location}/defaults.yaml
+  # Spire on, and auto-apply a mesh
+  cue eval -c ./k8s/outputs \
+           --out text \
+           -t spire=true \
+           -e operator_manifests_yaml > ../../${location}/withspire.yaml
+  # Spire off, and don't auto-apply a mesh (wait for a CR)
+  cue eval -c ./k8s/outputs \
+           --out text \
+           -t auto_apply_mesh=false \
+           -e operator_manifests_yaml > ../../${location}/noautoapply.yaml
+  # Spire on, and don't auto-apply a mesh (wait for a CR)
+  cue eval -c ./k8s/outputs \
+           --out text \
+           -t spire=true \
+           -t auto_apply_mesh=false \
+           -e operator_manifests_yaml > ../../${location}/withspire_noautoapply.yaml
+  )
+}
+
 usage() {
   cmd_help
   exit 1
@@ -71,7 +104,7 @@ if [ $# -eq 0 ]; then
 else
   MODE="${1:-}"
   case "$MODE" in
-    build|container|debug_container|debug|help)
+    build|container|debug_container|debug|manifests|help)
       shift
       "cmd_$MODE" "$@"
       ;;

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -54,6 +54,7 @@ cmd_build () {
   # Login to Nexus in order to add the greymatter CLI to the image.
   container-registry-login $NEXUS_USER $NEXUS_PASS
   _build_image "docker.greymatter.io/development/gm-operator:latest" "Dockerfile"
+  _build_manifests
 }
 
 # Build docker image helper
@@ -63,6 +64,10 @@ _build_image () {
   #TODO(coleman): find a way to NOT pass creds into our container build
   local build_args="--build-arg username=${NEXUS_USER} --build-arg password=${NEXUS_PASS}"
   buildah bud $build_args -t "${tag}" --layers -f ${dockerfile} .
+}
+
+_build_manifests () {
+  ./scripts/build manifests
 }
 
 # Logs into Nexus, checks if CI is running during a tag release or merge into main and if so pushes assets. 
@@ -87,6 +92,13 @@ cmd_export_container () {
   local tarball=$1
   local tag=$2
   podman save --quiet -o $tarball $tag
+  buildkite-agent artifact upload $tarball
+}
+
+# Exports a tarball of generated manifests
+cmd_export_manifests () {
+  local tarball=$1
+  tar -czvf $tarball manifests/
   buildkite-agent artifact upload $tarball
 }
 
@@ -159,7 +171,7 @@ fi
 CMD=$1
 shift
 case $CMD in
-  test|build|release|generate_integration_tests|wait_for_k3s|export_container|create_image_pull_secret|bootstrap)
+  test|build|release|generate_integration_tests|wait_for_k3s|export_container|export_manifests|create_image_pull_secret|bootstrap)
     cmd_$CMD $@
     ;;
   *)


### PR DESCRIPTION
[sc-13238]

Per [the plan described here](https://app.shortcut.com/grey-matter/story/13238/publish-operator-installation-manifests-to-our-website-curl-bash-script#activity-14086), build manifests to install the operator with certain flags already set.

These are intended to be published somewhere so that operator installation becomes simply a matter of applying them, e.g. with `kubectl apply -f https://greymatter.io/operator/v1.0_withspire.yaml` (followed immediately by creation of `gm-docker-secret` in the `gm-operator` namespace).