### PR TITLE
Tag test operator image with Buildkite env vars

### DIFF
--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -74,8 +74,10 @@ _build_manifests () {
 # Needs to download the previous assets in case the agent machine gets reassigned (in which case the build assets won't be there)
 _release_container () {
   local latest="docker.greymatter.io/development/gm-operator:latest"
+  local intermediate="docker.greymatter.io/development/gm-operator:${BUILDKITE_PIPELINE_SLUG}_${BUILDKITE_BUILD_NUMBER}"
   buildkite-agent artifact download "${BUILDKITE_PIPELINE_SLUG}_${BUILDKITE_BUILD_NUMBER}.tar" . --build ${BUILDKITE_BUILD_ID} --agent-access-token ${BUILDKITE_AGENT_ACCESS_TOKEN}
   podman load -q -i "${BUILDKITE_PIPELINE_SLUG}_${BUILDKITE_BUILD_NUMBER}.tar"
+  container-retag-image $intermediate $latest
   container-registry-login $NEXUS_USER $NEXUS_PASS
   if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
     container-registry-push $latest
@@ -91,7 +93,9 @@ _release_container () {
 cmd_export_container () {
   local tarball=$1
   local tag=$2
-  podman save --quiet -o $tarball $tag
+  local intermediate="docker.greymatter.io/development/gm-operator:${BUILDKITE_PIPELINE_SLUG}_${BUILDKITE_BUILD_NUMBER}"
+  container-retag-image $tag $intermediate
+  podman save --quiet -o $tarball $intermediate
   buildkite-agent artifact upload $tarball
 }
 

--- a/scripts/test
+++ b/scripts/test
@@ -29,7 +29,7 @@ _wait_for_resource() {
   local namespace=$2
   local timeout=$3
   if [ -z $3 ]; then
-    timeout=300
+    timeout=420
   fi
 
   while [ "$($KUBECTL_CMD get -n ${namespace} pods --selector ${selector} -o jsonpath='{.items[*].status.containerStatuses[0].ready}')" != "true" ]; do
@@ -46,7 +46,8 @@ _wait_for_resource() {
 # A helper function     Evaluates the CUE files to install the operator, overriding the config definitions with the values found in the tags
 install_operator () {
   local tags=$1
-  ( cd pkg/cuemodule && cue eval -c ./k8s/outputs -t operator_image='docker.greymatter.io/development/gm-operator:latest' $tags  --out text -e operator_manifests_yaml | $KUBECTL_CMD apply -f - )
+  local image_tag="${BUILDKITE_PIPELINE_SLUG}_${BUILDKITE_BUILD_NUMBER}"
+  ( cd pkg/cuemodule && cue eval -c ./k8s/outputs -t operator_image="docker.greymatter.io/development/gm-operator:$image_tag" $tags  --out text -e operator_manifests_yaml | $KUBECTL_CMD apply -f - )
 }
 
 #  A test case.   Asserts there are no mesh CRs present


### PR DESCRIPTION
This makes it so that if the path-activated systemd
service at /opt/k3s-import fails, our integration tests will
fail in a more obvious way. Relying on "latest", as usual, is bad.
