### PR TITLE
Don't inject sidecar if inject-sidecar-to annotation not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## vNEXT
+
+### Fixed
+
+- A sidecar is no longer injected if the inject-sidecar-to annotation is missing from a Deployment
+  or StatefulSet in a watched namespace.
+
 ## 0.9.0 (June 13, 2022)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNEXT
 
+### Changed
+
+- The annotations for deployment assist now need to be put in `spec.template.metadata.annotations`,
+  not the top-level `metadata.annotations` for the Deployment or StatefulSet.
+
 ### Fixed
 
 - A sidecar is no longer injected if the inject-sidecar-to annotation is missing from a Deployment

--- a/README.md
+++ b/README.md
@@ -31,9 +31,8 @@ cue eval -c ./k8s/outputs --out text -e operator_manifests_yaml | kubectl apply 
 
 kubectl create secret docker-registry gm-docker-secret \
   --docker-server=quay.io \
-  --docker-username=$GREYMATTER_REGISTRY_USERNAME \s
-  --docker-password=$GREYMATTER_REGISTRY_PASSWORD \
-  --docker-email=$GREYMATTER_REGISTRY_EMAIL \
+  --docker-username=$QUAY_USERNAME \
+  --docker-password=$QUAY_PASSWORD \
   -n gm-operator
   
   # EDIT THIS to reflect your own, or some other SSH private key with access,
@@ -111,7 +110,7 @@ spec:
 If you would like to attach a remote debugger to your operator container, do the following:
 ```bash
 # Builds and pushes quay.io/greymatterio/gm-operator:debug from Dockerfile.debug. Edit to taste.
-# You will need to have your credentials in $GREYMATTER_REGISTRY_USERNAME, $GREYMATTER_REGISTRY_EMAIL, and $GREYMATTER_REGISTRY_PASSWORD
+# You will need to have your credentials in $QUAY_USERNAME, and $QUAY_PASSWORD
 ./scripts/build debug_container
 
 # Push the image you just built to Nexus
@@ -128,9 +127,8 @@ cue eval -c ./k8s/outputs --out text \
 
 kubectl create secret docker-registry gm-docker-secret \
   --docker-server=quay.io \
-  --docker-username=$GREYMATTER_REGISTRY_USERNAME \
-  --docker-password=$GREYMATTER_REGISTRY_PASSWORD \
-  --docker-email=$GREYMATTER_REGISTRY_EMAIL \
+  --docker-username=$QUAY_USERNAME \
+  --docker-password=$QUAY_PASSWORD \
   -n gm-operator
 )
   

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ cd pkg/cuemodule/core
 cue eval -c ./k8s/outputs --out text -e operator_manifests_yaml | kubectl apply -f -
 
 kubectl create secret docker-registry gm-docker-secret \
-  --docker-server=docker.greymatter.io \
-  --docker-username=$GREYMATTER_REGISTRY_USERNAME \
+  --docker-server=quay.io \
+  --docker-username=$GREYMATTER_REGISTRY_USERNAME \s
   --docker-password=$GREYMATTER_REGISTRY_PASSWORD \
-  --docker-email=$GREYMATTER_REGISTRY_USERNAME \
+  --docker-email=$GREYMATTER_REGISTRY_EMAIL \
   -n gm-operator
   
   # EDIT THIS to reflect your own, or some other SSH private key with access,
@@ -48,7 +48,7 @@ kubectl create secret docker-registry gm-docker-secret \
 )
 ```
 
-> HINT: Your username and password are your Grey Matter credentials.
+> HINT: Your username and password are your Quay.io credentials authorized to the greymatterio organization.
 
 The operator will be running in a pod in the `gm-operator` namespace, and shortly after installation, the default Mesh
 CR described in `pkg/cuemodule/core/inputs.cue` will be automatically deployed.
@@ -62,27 +62,27 @@ before spire-server and spire-agent can successfully launch.
 
 If you would like to attach a remote debugger to your operator container, do the following:
 ```bash
-# Builds and pushes docker.greymatter.io/internal/gm-operator:debug from Dockerfile.debug. Edit to taste.
-# You will need to have your credentials in $GREYMATTER_REGISTRY_USERNAME and $GREYMATTER_REGISTRY_PASSWORD
+# Builds and pushes quay.io/greymatterio/gm-operator:debug from Dockerfile.debug. Edit to taste.
+# You will need to have your credentials in $GREYMATTER_REGISTRY_USERNAME, $GREYMATTER_REGISTRY_EMAIL, and $GREYMATTER_REGISTRY_PASSWORD
 ./scripts/build debug_container
 
 # Push the image you just built to Nexus
-docker push docker.greymatter.io/internal/gm-operator:latest-debug
+docker push quay.io/greymatterio/gm-operator:latest-debug
 
 # Launch the operator with the debug build in debug mode.
 # Note the two tags (`operator_image` and `debug`) which are the only differences from Getting Started
 ( 
 cd pkg/cuemodule
 cue eval -c ./k8s/outputs --out text \
-         -t operator_image=docker.greymatter.io/internal/gm-operator:latest-debug \
+         -t operator_image=quay.io/greymatterio/gm-operator:latest-debug \
          -t debug=true \
          -e operator_manifests_yaml | kubectl apply -f -
 
 kubectl create secret docker-registry gm-docker-secret \
-  --docker-server=docker.greymatter.io \
+  --docker-server=quay.io \
   --docker-username=$GREYMATTER_REGISTRY_USERNAME \
   --docker-password=$GREYMATTER_REGISTRY_PASSWORD \
-  --docker-email=$GREYMATTER_REGISTRY_USERNAME \
+  --docker-email=$GREYMATTER_REGISTRY_EMAIL \
   -n gm-operator
 )
   
@@ -127,7 +127,7 @@ been provided at the root of this project to launch the operator in a local
 
 Some caveats:
 * You should have Docker and Nix installed
-* You should be able to login to `docker.greymatter.io`
+* You should be able to log in to `quay.io`
 
 To launch, simply run:
 ```bash

--- a/pkg/gmapi/cli.go
+++ b/pkg/gmapi/cli.go
@@ -10,7 +10,6 @@ import (
 	"github.com/greymatter-io/operator/api/v1alpha1"
 	"github.com/greymatter-io/operator/pkg/cuemodule"
 	"github.com/greymatter-io/operator/pkg/wellknown"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"strconv"
 	"sync"
@@ -117,8 +116,8 @@ func (c *CLI) RemoveMeshClient() {
 
 // ConfigureSidecar applies fabric objects that add a workload to the mesh specified
 // given the workload's annotations and a list of its corev1.Containers.
-func (c *CLI) ConfigureSidecar(operatorCUE *cuemodule.OperatorCUE, name string, metadata metav1.ObjectMeta) {
-	annotations := metadata.Annotations
+func (c *CLI) ConfigureSidecar(operatorCUE *cuemodule.OperatorCUE, name string, annotations map[string]string) {
+	//annotations := metadata.Annotations
 	injectedSidecarPortString, injectSidecar := annotations[wellknown.ANNOTATION_INJECT_SIDECAR_TO_PORT]
 	var injectedSidecarPort int
 	if injectSidecar {
@@ -158,8 +157,8 @@ func (c *CLI) EnsureClient(in string) {
 }
 
 // UnconfigureSidecar removes fabric objects, disconnecting the workload from the mesh specified
-func (c *CLI) UnconfigureSidecar(operatorCUE *cuemodule.OperatorCUE, name string, metadata metav1.ObjectMeta) {
-	annotations := metadata.Annotations
+func (c *CLI) UnconfigureSidecar(operatorCUE *cuemodule.OperatorCUE, name string, annotations map[string]string) {
+	//annotations := metadata.Annotations
 	logger.Info("Unconfiguring sidecar with values", "name", name, "annotations", annotations)
 	injectedSidecarPortString, injectSidecar := annotations[wellknown.ANNOTATION_INJECT_SIDECAR_TO_PORT]
 	var injectedSidecarPort int

--- a/pkg/gmapi/cli.go
+++ b/pkg/gmapi/cli.go
@@ -133,8 +133,8 @@ func (c *CLI) ConfigureSidecar(operatorCUE *cuemodule.OperatorCUE, name string, 
 	}
 
 	// we skip configuration if we're explicitly told to
-	configureSidecar := annotations[wellknown.ANNOTATION_CONFIGURE_SIDECAR]
-	if configureSidecar == "false" {
+	configureSidecar, configureSidecarPresent := annotations[wellknown.ANNOTATION_CONFIGURE_SIDECAR]
+	if !configureSidecarPresent || configureSidecar == "false" {
 		return
 	}
 

--- a/pkg/mesh_install/install.go
+++ b/pkg/mesh_install/install.go
@@ -36,8 +36,16 @@ func (i *Installer) ApplyMesh(prev, mesh *v1alpha1.Mesh) {
 		k8sapi.Apply(i.K8sClient, secret, mesh, k8sapi.GetOrCreate)
 	}
 
-	// Copy the imagePullSecret into all watched namespaces
 	for _, watchedNS := range mesh.Spec.WatchNamespaces {
+		// Create all watched namespaces, if they don't already exist
+		namespace := &v1.Namespace{
+			TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: mesh.Spec.InstallNamespace,
+			},
+		}
+		k8sapi.Apply(i.K8sClient, namespace, mesh, k8sapi.GetOrCreate)
+		// Copy the imagePullSecret into all watched namespaces
 		secret := i.imagePullSecret.DeepCopy()
 		secret.Namespace = watchedNS
 		k8sapi.Apply(i.K8sClient, secret, mesh, k8sapi.GetOrCreate)

--- a/pkg/mesh_install/install.go
+++ b/pkg/mesh_install/install.go
@@ -41,7 +41,7 @@ func (i *Installer) ApplyMesh(prev, mesh *v1alpha1.Mesh) {
 		namespace := &v1.Namespace{
 			TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: mesh.Spec.InstallNamespace,
+				Name: watchedNS,
 			},
 		}
 		k8sapi.Apply(i.K8sClient, namespace, mesh, k8sapi.GetOrCreate)

--- a/pkg/webhooks/workloads.go
+++ b/pkg/webhooks/workloads.go
@@ -66,6 +66,11 @@ func (wd *workloadDefaulter) handlePod(req admission.Request) admission.Response
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
+	annotations := pod.Annotations
+	if _, injectSidecar := annotations[wellknown.ANNOTATION_INJECT_SIDECAR_TO_PORT]; !injectSidecar {
+		return admission.ValidationResponse(true, "allowed")
+	}
+
 	// Check for a cluster label; if not found, this pod does not belong to a Mesh.
 	clusterLabel, ok := pod.Labels[wellknown.LABEL_CLUSTER]
 	if !ok {

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -47,7 +47,7 @@ cmd_create_secrets () {
     --docker-server=quay.io \
     --docker-username="$QUAY_USERNAME" \
     --docker-password="$QUAY_PASSWORD" \
-    --docker-email=$QUAY_USERNAME -n $ns
+    -n $ns
 
   # SSH key secret for GitOps
   kubectl create secret generic greymatter-sync-secret \

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -44,10 +44,10 @@ cmd_create_secrets () {
 
   # Image pull secret
   k3s kubectl create secret docker-registry $name \
-    --docker-server=docker.greymatter.io \
-    --docker-username="$NEXUS_USER" \
-    --docker-password="$NEXUS_PASS" \
-    --docker-email=$NEXUS_USER -n $ns
+    --docker-server=quay.io \
+    --docker-username="$QUAY_USERNAME" \
+    --docker-password="$QUAY_PASSWORD" \
+    --docker-email=$QUAY_USERNAME -n $ns
 
   # SSH key secret for GitOps
   kubectl create secret generic greymatter-sync-secret \


### PR DESCRIPTION
[sc-17445]
A regression is causing sidecars to be injected even if there's no inject-sidecar-to annotation on the Deployment or StatefulSet. This PR should fix that.

[sc-17490]
Besides documentation on that, this PR also updates the CI build to use Quay.io for Grey Matter component images, bumps `pkg/cuemodule/core` to the latest gitops-core, and creates watched namespaces automatically when they don't already exist.