### PR TITLE
Upgrade packaged CLI to 4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Upgraded the packaged greymatter CLI version to 4.2.
+
 ## 0.9.1 (June 16, 2022)
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG username
 ARG password
 ENV USERNAME=$username
 ENV PASSWORD=$password
-COPY scripts/cli cli
+COPY scripts/get_greymatter_cli cli
 RUN ./cli
 
 # Build

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -18,7 +18,7 @@ ARG username
 ARG password
 ENV USERNAME=$username
 ENV PASSWORD=$password
-COPY scripts/cli cli
+COPY scripts/cli_greymatter_cli cli
 RUN ./cli
 
 # Build

--- a/pkg/gmapi/cli.go
+++ b/pkg/gmapi/cli.go
@@ -78,9 +78,9 @@ func (c *CLI) ConfigureMeshClient(mesh *v1alpha1.Mesh) {
 func mkCLIConfig(apiHost, catalogHost, catalogMesh string) string {
 	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`
 	[api]
-	host = "%s"
+	url = "%s"
 	[catalog]
-	host = "%s"
+	url = "%s"
 	mesh = "%s"
 	`, apiHost, catalogHost, catalogMesh)))
 }

--- a/pkg/gmapi/client.go
+++ b/pkg/gmapi/client.go
@@ -74,15 +74,15 @@ func newClient(operatorCUE *cuemodule.OperatorCUE, mesh *v1alpha1.Mesh, flags ..
 				return
 			case c := <-controlCmds:
 				// Requeue failed commands, since there are likely object dependencies (TODO: check)
-				if _, err := c.run(client.flags); err != nil && c.requeue {
-					logger.Info("command failed, will reattempt in 10 seconds", "args", c.args)
+				if response, err := c.run(client.flags); err != nil && c.requeue {
+					logger.Info("command failed, will reattempt in 10 seconds", "args", c.args, "error", err, "response", response)
 					go func(args string) {
 						time.Sleep(10 * time.Second)
 						select {
 						case <-ctx.Done():
 							return
 						default:
-							logger.Info("requeued failed command", "args", args)
+							logger.Info("requeuing failed command", "args", args)
 							controlCmds <- c
 						}
 					}(c.args)
@@ -123,15 +123,15 @@ func newClient(operatorCUE *cuemodule.OperatorCUE, mesh *v1alpha1.Mesh, flags ..
 				return
 			case c := <-catalogCmds:
 				// Requeue failed commands, since there are likely object dependencies (TODO: check)
-				if _, err := c.run(client.flags); err != nil && c.requeue {
-					logger.Info("command failed, will reattempt in 10 seconds", "args", c.args)
+				if response, err := c.run(client.flags); err != nil && c.requeue {
+					logger.Info("command failed, will reattempt in 10 seconds", "args", c.args, "error", err, "response", response)
 					go func(args string) {
 						time.Sleep(10 * time.Second)
 						select {
 						case <-ctx.Done():
 							return
 						default:
-							logger.Info("requeued failed command", "args", args)
+							logger.Info("requeuing failed command", "args", args)
 							catalogCmds <- c
 						}
 					}(c.args)

--- a/pkg/gmapi/commands.go
+++ b/pkg/gmapi/commands.go
@@ -3,8 +3,6 @@ package gmapi
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
-
 	"github.com/tidwall/gjson"
 )
 
@@ -20,13 +18,6 @@ func MkApply(kind string, data json.RawMessage) Cmd {
 			} else {
 				logger.Info("apply", "type", kind, "key", key)
 			}
-		},
-		modify: func(out []byte) ([]byte, error) {
-			outStr := string(out)
-			if !strings.Contains(outStr, "200") {
-				return out, fmt.Errorf(string(out))
-			}
-			return out, nil
 		},
 	}
 }

--- a/scripts/get_greymatter_cli
+++ b/scripts/get_greymatter_cli
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-tarball="greymatter-4.0.1-linux-amd64.tar.gz"
+tarball="greymatter_4.2.0_linux_amd64.tar.gz"
 wget --user=$USERNAME --password=$PASSWORD -q -c "https://nexus.greymatter.io/repository/raw/release/gm-cli/${tarball}"
 tar -xzf ${tarball} greymatter
 chmod +x greymatter


### PR DESCRIPTION
[sc-19021]

This turned out to be quite straightforward, despite some unrelated weirdness holding things up. Two changes needed to be made in the operator to support the 4.0.1 -> 4.2.0 upgrade, other than the upgrade itself:

- "host" -> "url" in the embedded config.toml
- use error codes instead of a response containing "200"

If the build succeeds, this PR is good to go, since the integration tests exercise the mesh config deployment code including using the new CLI version.