### PR TITLE
Change CI container to ubuntu-2204-ci

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,13 +1,13 @@
 steps:
   - label: "run unit tests"
     agents:
-      container_image: ubuntu-2110-ci
+      container_image: ubuntu-2204-ci
     commands:
       - ./scripts/cibuild bootstrap
       - ./scripts/cibuild test
   - label: ":shipit: build"
     agents:
-      container_image: ubuntu-2110-ci
+      container_image: ubuntu-2204-ci
     commands:
       - ./scripts/cibuild bootstrap
       - ./scripts/cibuild build
@@ -22,9 +22,9 @@ steps:
     commands:
       - ./scripts/cibuild generate_integration_tests
     agents:
-      container_image: ubuntu-2110-ci
+      container_image: ubuntu-2204-ci
   - wait
   - label: "release"
     agents:
-      container_image: ubuntu-2110-ci
+      container_image: ubuntu-2204-ci
     command: "./scripts/cibuild release"

--- a/.buildkite/scheduled-build.yaml
+++ b/.buildkite/scheduled-build.yaml
@@ -1,6 +1,6 @@
 agents:
   queue: default
-  container_image: ubuntu-2110-ci
+  container_image: ubuntu-2204-ci
 
 steps:
   - label: "Scheduled build"


### PR DESCRIPTION
22.04 is preferred; it is a long-term release (LTS). Refs [sc-12654]